### PR TITLE
docs: reconcile algorithm count to the paper canon (15 = 9+6; package = 10 core + 10 advanced)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] — 2026-06-27
+
+### Documentation consistency
+
+Cosmetic patch — no code changes. Reconciles the algorithm-count wording across the repo and the npm package so it matches the architecture described in the paper:
+
+- The **architecture** is **15 neuroscience-inspired mechanisms — 9 foundational algorithms + 6 PMA components** (the 6 PMA are proprietary; see the [paper](https://arxiv.org/abs/2604.23878)). Stated as a clear callout in the root and package READMEs.
+- The **open-source package** ships **20 algorithm modules (10 core + 10 advanced)** — corrected from the previous "22 / 12 core" miscount (the old "12 core" counted 10 algorithms plus shared `types`).
+- `package.json` description, `docs/ROADMAP.md`, and historical changelog counts aligned to 10 core / 20 total.
+
+No algorithm code or APIs changed.
+
 ## [0.2.2] — 2026-05-24
 
 `@zensation/core` patch — packaging + dependency hygiene. No runtime API changes.
@@ -60,7 +72,7 @@ Adds 10 advanced algorithms grounded in recent neuroscience and ML research to t
 - **+250 new tests** (429 total, 179 existing + 250 new). All passing on vitest.
 
 ### Build
-- `tsup` ESM + CJS + DTS dual format extended to all 22 algorithm modules.
+- `tsup` ESM + CJS + DTS dual format extended to all 20 algorithm modules.
 - Package size: 379 KB packed, 1.7 MB unpacked, 152 files.
 
 ### Breaking changes
@@ -98,7 +110,7 @@ Adds 10 advanced algorithms grounded in recent neuroscience and ML research to t
 
 ### Added
 - Initial public release.
-- 12 neuroscience-inspired memory algorithms (FSRS, Ebbinghaus, Hebbian, Bayesian, Emotional, Context-Retrieval, Similarity, Intervals, Visualization, Sleep-Consolidation, plus shared types).
+- 10 neuroscience-inspired memory algorithms (FSRS, Ebbinghaus, Hebbian, Bayesian, Emotional, Context-Retrieval, Similarity, Intervals, Visualization, Sleep-Consolidation, plus shared types).
 - 7-layer memory system (Working, Short-Term, Episodic, Semantic, Procedural, Core, Cross-Context).
 - Pluggable storage / embeddings / LLM providers.
 - Apache-2.0 license.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <h1 align="center">ZenBrain</h1>
   <p align="center"><strong>The neuroscience-inspired memory system for AI agents.</strong></p>
-  <p align="center">7 memory layers. 22 neuroscience-inspired algorithms. FSRS, Hebbian, Sleep consolidation, Emotional tagging — plus 10 advanced algorithms (vmPFC-FSRS, two-factor Hebbian, simulation-selection sleep, Fiedler-value KG health, IB budget, Hopfield STM, Personalized PageRank, ...).<br/>Pure TypeScript. Zero dependencies. 528 tests. Extracted from a production AI platform.</p>
+  <p align="center">7 memory layers. Real neuroscience — FSRS, Hebbian, sleep consolidation, emotional tagging, plus 10 advanced research modules (vmPFC-FSRS, two-factor Hebbian, simulation-selection sleep, Fiedler-value KG health, IB budget, Hopfield STM, ...).<br/>Pure TypeScript. Zero dependencies. 528 tests. Extracted from a production AI platform.</p>
 </p>
 
 <p align="center">
@@ -56,6 +56,8 @@ Feedback, replications, and counter-results are explicitly welcome — please op
 
 > **Your AI forgets everything after every conversation.** ZenBrain fixes that — with the same mechanisms your brain uses: spaced repetition, emotional consolidation, Hebbian strengthening, and exponential forgetting curves. Not a vector database with a wrapper. Actual neuroscience.
 
+> **Architecture vs. this package.** ZenBrain's architecture is **15 neuroscience-inspired mechanisms — 9 foundational algorithms + 6 Predictive Memory Architecture (PMA) components** ([paper](https://arxiv.org/abs/2604.23878)). The 6 PMA components are proprietary and run in the production system. **This open-source package ships the algorithm library: 10 core algorithms + 10 advanced research modules (20 modules), zero-dependency.**
+
 ---
 
 ## Comparison with related open-source memory systems
@@ -84,7 +86,7 @@ ZenBrain brings these mechanisms to AI agents:
 
 ### Advanced algorithms (v0.3.0, May 2026)
 
-On top of the 12 core algorithms above, `@zensation/algorithms@0.3.0` ships 10 advanced algorithms grounded in recent neuroscience and ML research. Each is exposed as its own sub-path (`@zensation/algorithms/<name>`) and remains zero-dependency:
+On top of the 10 core algorithms above, `@zensation/algorithms@0.3.0` ships 10 advanced algorithms grounded in recent neuroscience and ML research. Each is exposed as its own sub-path (`@zensation/algorithms/<name>`) and remains zero-dependency:
 
 - **`fsrs-vmPFC`** — Prediction-Error coupled FSRS
 - **`hebbian-two-factor`** — Two-Factor synaptic consolidation
@@ -240,7 +242,7 @@ const dueItems = await memory.getReviewQueue();
 
 | Package | Description | Status |
 |---------|-------------|--------|
-| [`@zensation/algorithms`](./packages/algorithms) | 22 neuroscience algorithms — 12 core (FSRS, Hebbian, Ebbinghaus, emotional, Bayesian, sleep consolidation, intervals, visualization) + 10 advanced (vmPFC-FSRS, two-factor Hebbian, IB budget, Hopfield STM, …) | :white_check_mark: Published |
+| [`@zensation/algorithms`](./packages/algorithms) | 20 algorithm modules — 10 core (FSRS, Hebbian, Ebbinghaus, emotional, Bayesian, sleep consolidation, intervals, visualization) + 10 advanced (vmPFC-FSRS, two-factor Hebbian, IB budget, Hopfield STM, …) | :white_check_mark: Published |
 | [`@zensation/core`](./packages/core) | Memory layers, coordinator, adapter interfaces | :white_check_mark: Published |
 | [`@zensation/adapter-postgres`](./packages/adapters/postgres) | PostgreSQL + pgvector storage adapter | :white_check_mark: Ready |
 | [`@zensation/adapter-sqlite`](./packages/adapters/sqlite) | SQLite storage adapter (zero-config) | :white_check_mark: Ready |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,8 +11,8 @@ external deadlines; the items below are directions, not dated commitments.
 
 ### v0.3 — Advanced algorithms (May 2026)
 
-- `@zensation/algorithms@0.3.x` — 10 advanced algorithms added on top of the 12
-  core ones (**22 total**), each a zero-dependency subpath export: prediction-error
+- `@zensation/algorithms@0.3.x` — 10 advanced algorithms added on top of the 10
+  core ones (**20 total**), each a zero-dependency subpath export: prediction-error
   coupled FSRS (`fsrs-vmPFC`), two-factor synaptic Hebbian, simulation-selection
   sleep, spectral (Fiedler-value) KG health, Information-Bottleneck budget,
   dopamine-modulated routing, Hopfield STM, Personalized PageRank,
@@ -30,7 +30,7 @@ external deadlines; the items below are directions, not dated commitments.
 
 ### v0.1 — Foundation (March 2026)
 
-- Initial public release: the 7-layer memory architecture and 12 core
+- Initial public release: the 7-layer memory architecture and 10 core
   neuroscience-inspired algorithms (FSRS, Ebbinghaus, Hebbian, Bayesian,
   emotional, context-retrieval, similarity, intervals, visualization,
   sleep-consolidation, shared types).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2767,7 +2767,7 @@
     },
     "packages/algorithms": {
       "name": "@zensation/algorithms",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/algorithms/README.md
+++ b/packages/algorithms/README.md
@@ -9,9 +9,11 @@
 
 ## What's Inside
 
-**22 neuroscience-inspired algorithms**, extracted from a production AI platform and published as standalone, dependency-free modules. Pure TypeScript, zero runtime dependencies, tree-shakeable subpath exports, 429 tests.
+**20 algorithm modules** (10 core + 10 advanced), extracted from a production AI platform and published as standalone, dependency-free modules. Pure TypeScript, zero runtime dependencies, tree-shakeable subpath exports, 429 tests.
 
-### Core (12 algorithms — since v0.2.x)
+> ZenBrain's full architecture is **15 neuroscience-inspired mechanisms (9 foundational + 6 PMA)** ([paper](https://arxiv.org/abs/2604.23878)). The 6 PMA components are proprietary; this open-source package ships the algorithm library described below.
+
+### Core (10 algorithms — since v0.2.x)
 
 | Algorithm | Inspired By | What It Does |
 |-----------|------------|--------------|

--- a/packages/algorithms/package.json
+++ b/packages/algorithms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/algorithms",
-  "version": "0.3.3",
-  "description": "22 neuroscience-inspired memory algorithms for AI agents: FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation, plus 10 advanced algorithms (vmPFC-FSRS, two-factor Hebbian, simulation-selection sleep, Fiedler-value KG health, Information-Bottleneck budget, Hopfield STM, Personalized PageRank, ...). Zero dependencies.",
+  "version": "0.3.4",
+  "description": "ZenBrain's open-source memory algorithm library: 10 core algorithms (FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation, Bayesian confidence, ...) + 10 advanced research modules (vmPFC-FSRS, two-factor Hebbian, simulation-selection sleep, Fiedler-value KG health, Information-Bottleneck budget, Hopfield STM, Personalized PageRank, ...). 20 modules, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Why

The public repo + npm package variously stated **"22 algorithms / 12 core"**, which **contradicts the paper and website canon** of **15 neuroscience-inspired mechanisms (9 foundational + 6 PMA)** (arXiv:2604.23878 abstract: "15 validated neuroscience mechanisms").

**Root cause:** the "12 core" count included 10 algorithms **plus shared `types`**; "22" followed from `12 + 10`. The package actually ships **20 algorithm modules** (10 core + 10 advanced, verified against `exports`).

## What changed (docs only — no code, no API)

- **New "Architecture vs. this package" callout** (root + package README): the architecture is **15 mechanisms (9 foundational + 6 PMA)**; the **6 PMA are proprietary**; this OSS package ships the **20-module algorithm library**.
- **Counts corrected** everywhere: `22 → 20`, `12 core → 10 core` (README, package README, `package.json` description, `docs/ROADMAP.md`, `CHANGELOG.md` history).
- **`@zensation/algorithms` `0.3.3 → 0.3.4`** (docs/description only) so the npm page can refresh on republish.

## Verification

- `npm test` — **429/429 pass**; `npm run build` clean.
- No algorithm code or public API touched.
- Embargo-safe: no venue / review-status wording added or present.

## After merge

`@zensation/algorithms@0.3.4` needs an `npm publish` (maintainer creds) so npmjs.com renders the corrected README/description.