### PR TITLE
ci: publish via npm trusted publishing (OIDC), no stored token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,14 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20 bundles npm 10.x.
+      - name: Upgrade npm (trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@^11.5.1
       - run: npm install --no-package-lock
       - run: cd packages/algorithms && npm run build
       - run: cd packages/core && npm run build
+      # Auth is via OIDC trusted publishing configured on npmjs.com (no NPM_TOKEN);
+      # provenance attestations are generated automatically.
       # Idempotent: only publish a version that is not already on the registry,
       # so re-tagging or a tag that touches only one package never fails.
       - name: Publish algorithms (skip if already published)
@@ -79,10 +84,8 @@ jobs:
           if npm view "@zensation/algorithms@$VERSION" version >/dev/null 2>&1; then
             echo "@zensation/algorithms@$VERSION already on npm — skipping"
           else
-            npm publish --provenance --access public
+            npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish core (skip if already published)
         run: |
           cd packages/core
@@ -90,7 +93,5 @@ jobs:
           if npm view "@zensation/core@$VERSION" version >/dev/null 2>&1; then
             echo "@zensation/core@$VERSION already on npm — skipping"
           else
-            npm publish --provenance --access public
+            npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The release job currently authenticates to npm with a stored \`NPM_TOKEN\` and the account enforces 2FA for publishing, so automated tag-triggered releases fail (a CI runner can't supply an OTP).

This switches publishing to **OIDC trusted publishing**, npm's current best practice:
- **No long-lived npm secret** in GitHub — nothing to leak or rotate.
- **Provenance stays automatic** (the job already had \`id-token: write\`).
- **Account 2FA can stay fully enforced** for humans.

## What changed (`.github/workflows/ci.yml`, publish job only)

- Upgrade npm to \`>= 11.5.1\` in the job (OIDC trusted publishing requires it; Node 20 ships npm 10.x).
- Drop \`NODE_AUTH_TOKEN\` / \`secrets.NPM_TOKEN\` — auth is now via OIDC.
- Drop the explicit \`--provenance\` flag — provenance is generated automatically under trusted publishing.

No change to the \`test\` job, triggers, or the idempotent "skip if already published" logic.

## ⚠️ Required one-time setup on npmjs.com BEFORE merging / next release tag

For **each** package, add GitHub Actions as a trusted publisher (package → Settings → Trusted Publisher):

- **Organization/User:** \`zensation-ai\`
- **Repository:** \`zenbrain\`
- **Workflow filename:** \`ci.yml\`
- **Environment:** *(leave blank)*

Packages: \`@zensation/algorithms\`, \`@zensation/core\`.

**Order:** configure the trusted publisher on npm first, then merge this PR. Releases are tag-triggered (\`v*\`) and manual, so there is no publish between the two steps. Once both are done, the \`NPM_TOKEN\` repo secret can be deleted.