### PR TITLE
fix(adapter-sqlite): make the SQLite path work end to end (store, vector recall, procedural schema)

### DIFF
--- a/packages/adapters/sqlite/__tests__/coordinator-integration.test.ts
+++ b/packages/adapters/sqlite/__tests__/coordinator-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { MemoryCoordinator, FakeEmbeddingProvider } from '@zensation/core';
+import { MemoryCoordinator, EpisodicMemory, FakeEmbeddingProvider } from '@zensation/core';
 import { createMemoryAdapter } from '../src/index.js';
 
 // ── Coordinator ↔ SqliteAdapter integration ────────────────────────────────────
@@ -134,6 +134,38 @@ describe('SqliteAdapter vector + parameter translation', () => {
     const names = columns.map(c => c.name);
     expect(names).toContain('trigger');
     expect(names).not.toContain('trigger_text');
+    await adapter.close();
+  });
+});
+
+describe('episodic layer on SqliteAdapter', () => {
+  it('filters getRecent by context without swapping parameters', async () => {
+    // Regression: getRecent() builds `WHERE context = $2 ... LIMIT $1` — $2 appears
+    // *before* $1 in the SQL text. Translating $N to anonymous `?` bound them
+    // positionally, so context got the limit and LIMIT got the context string
+    // ("datatype mismatch"). Numbered ?N placeholders bind by index, not position.
+    const adapter = createMemoryAdapter();
+    const episodic = new EpisodicMemory({
+      storage: adapter,
+      embedding: new FakeEmbeddingProvider(),
+    });
+
+    await episodic.store('Shipped the release', 'work');
+    await episodic.store('Hiked the coast path', 'holiday');
+    await episodic.store('Reviewed the roadmap', 'work');
+
+    const work = await episodic.getRecent(10, 'work');
+    expect(work).toHaveLength(2);
+    expect(work.every(e => e.context === 'work')).toBe(true);
+
+    const holiday = await episodic.getRecent(10, 'holiday');
+    expect(holiday).toHaveLength(1);
+    expect(holiday[0].content).toBe('Hiked the coast path');
+
+    // The unfiltered path uses only $1 and must keep working.
+    const all = await episodic.getRecent(10);
+    expect(all).toHaveLength(3);
+
     await adapter.close();
   });
 });

--- a/packages/adapters/sqlite/__tests__/coordinator-integration.test.ts
+++ b/packages/adapters/sqlite/__tests__/coordinator-integration.test.ts
@@ -121,4 +121,38 @@ describe('SqliteAdapter vector + parameter translation', () => {
     expect(result.rows[0].d).toBe(1);
     await adapter.close();
   });
+
+  it('names procedural_memories.trigger as the core layer queries it', async () => {
+    // Regression: the schema called this column `trigger_text`, so every
+    // ProceduralMemory.record() insert failed with "no column named trigger".
+    // The canonical schema is adapters/postgres/sql/001_init.sql.
+    const adapter = createMemoryAdapter();
+    const columns = adapter
+      .getDatabase()
+      .prepare('PRAGMA table_info(procedural_memories)')
+      .all() as { name: string }[];
+    const names = columns.map(c => c.name);
+    expect(names).toContain('trigger');
+    expect(names).not.toContain('trigger_text');
+    await adapter.close();
+  });
+});
+
+describe('procedural layer on SqliteAdapter', () => {
+  it('records a procedure end to end', async () => {
+    const adapter = createMemoryAdapter();
+    const coordinator = new MemoryCoordinator({
+      storage: adapter,
+      embedding: new FakeEmbeddingProvider(),
+    });
+    await expect(
+      coordinator.store('Deploy by running npm run build then pushing the tag.', {
+        type: 'procedure',
+        steps: ['npm run build', 'git push --tags'],
+        tools: ['npm', 'git'],
+        outcome: 'released',
+      }),
+    ).resolves.toBeTruthy();
+    await adapter.close();
+  });
 });

--- a/packages/adapters/sqlite/__tests__/coordinator-integration.test.ts
+++ b/packages/adapters/sqlite/__tests__/coordinator-integration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryCoordinator, FakeEmbeddingProvider } from '@zensation/core';
+import { createMemoryAdapter } from '../src/index.js';
+
+// ── Coordinator ↔ SqliteAdapter integration ────────────────────────────────────
+//
+// Regression coverage for three bugs that unit tests missed because nothing
+// exercised the real core→adapter path:
+//  1. store() threw: fsrs_next_review was bound as a Date object, which
+//     better-sqlite3 cannot bind.
+//  2. recall() was silently empty: `embedding <=> ?` was rewritten to the
+//     constant 0, producing `ORDER BY 0` (invalid in SQLite); the coordinator
+//     swallowed the error per layer.
+//  3. Numbered placeholders (?1) are named parameters in better-sqlite3 and
+//     must be object-bound; positional spreading threw "Too many parameter
+//     values were provided".
+
+describe('MemoryCoordinator on SqliteAdapter', () => {
+  const adapters: { close(): Promise<void> }[] = [];
+
+  function makeCoordinator() {
+    const adapter = createMemoryAdapter();
+    adapters.push(adapter);
+    return new MemoryCoordinator({
+      storage: adapter,
+      embedding: new FakeEmbeddingProvider(),
+    });
+  }
+
+  afterEach(async () => {
+    while (adapters.length) await adapters.pop()!.close();
+  });
+
+  it('stores semantic facts without throwing (Date param coercion)', async () => {
+    const coordinator = makeCoordinator();
+    const id = await coordinator.store('The capital of France is Paris.', {
+      type: 'fact',
+      source: 'test',
+    });
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('recalls stored facts via vector search (no silent empty result)', async () => {
+    const coordinator = makeCoordinator();
+    await coordinator.store('My sister Anna lives in Hamburg.', { type: 'fact', source: 'test' });
+    await coordinator.store('The capital of France is Paris.', { type: 'fact', source: 'test' });
+    await coordinator.store('Water boils at 100 degrees Celsius.', { type: 'fact', source: 'test' });
+
+    const results = await coordinator.recall('Anna Hamburg', { limit: 5 });
+
+    expect(results.length).toBeGreaterThan(0);
+    const semantic = results.filter(r => r.layer === 'semantic');
+    expect(semantic.length).toBeGreaterThan(0);
+    for (const r of semantic) {
+      expect(typeof r.content).toBe('string');
+      expect(typeof r.score).toBe('number');
+    }
+  });
+
+  it('round-trips the full auto-routing store path', async () => {
+    const coordinator = makeCoordinator();
+    // 'auto' routes plain declarative text to the semantic layer — the exact
+    // path that crashed before the Date fix.
+    await expect(
+      coordinator.store('TypeScript is a typed superset of JavaScript.', {
+        type: 'auto',
+        source: 'test',
+      }),
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe('SqliteAdapter vector + parameter translation', () => {
+  it('binds repeated numbered placeholders from a single parameter', async () => {
+    const adapter = createMemoryAdapter();
+    const result = await adapter.query<{ a: number; b: number; c: number }>(
+      'SELECT $1 as a, $1 as b, $2 as c',
+      [7, 9],
+    );
+    expect(result.rows[0]).toEqual({ a: 7, b: 7, c: 9 });
+    await adapter.close();
+  });
+
+  it('computes real cosine distance and orders by it', async () => {
+    const adapter = createMemoryAdapter();
+    const db = adapter.getDatabase();
+    db.prepare(
+      `INSERT INTO learned_facts (id, content, confidence, source, embedding,
+        fsrs_difficulty, fsrs_stability, fsrs_next_review, access_count, created_at, last_accessed)
+       VALUES ('a', 'aligned', 0.7, 'test', '[1,0]', 5, 7, '2030-01-01', 0, datetime('now'), datetime('now'))`,
+    ).run();
+    db.prepare(
+      `INSERT INTO learned_facts (id, content, confidence, source, embedding,
+        fsrs_difficulty, fsrs_stability, fsrs_next_review, access_count, created_at, last_accessed)
+       VALUES ('b', 'orthogonal', 0.7, 'test', '[0,1]', 5, 7, '2030-01-01', 0, datetime('now'), datetime('now'))`,
+    ).run();
+
+    // Exactly the shape the semantic layer sends: $1 twice, $2 once.
+    const result = await adapter.query<{ id: string; score: number }>(
+      `SELECT id, 1 - (embedding <=> $1::vector) as score
+       FROM learned_facts
+       WHERE embedding IS NOT NULL
+       ORDER BY embedding <=> $1::vector
+       LIMIT $2`,
+      ['[1,0]', 5],
+    );
+
+    expect(result.rows.map(r => r.id)).toEqual(['a', 'b']);
+    expect(result.rows[0].score).toBeCloseTo(1, 5); // identical vector → similarity 1
+    expect(result.rows[1].score).toBeCloseTo(0, 5); // orthogonal → similarity 0
+    await adapter.close();
+  });
+
+  it('gives unparsable embeddings max distance instead of crashing', async () => {
+    const adapter = createMemoryAdapter();
+    const result = await adapter.query<{ d: number }>(
+      `SELECT zb_cosine_dist('not-a-vector', $1) as d`,
+      ['[1,0]'],
+    );
+    expect(result.rows[0].d).toBe(1);
+    await adapter.close();
+  });
+});

--- a/packages/adapters/sqlite/src/index.ts
+++ b/packages/adapters/sqlite/src/index.ts
@@ -256,7 +256,11 @@ export class SqliteAdapter implements StorageAdapter {
       -- Layer 5: Procedural Memory
       CREATE TABLE IF NOT EXISTS procedural_memories (
         id TEXT PRIMARY KEY,
-        trigger_text TEXT NOT NULL,
+        -- Must match the canonical schema (adapters/postgres/sql/001_init.sql),
+        -- which ProceduralMemory queries by this name. SQLite accepts trigger as
+        -- an unquoted column name despite TRIGGER being a keyword; calling it
+        -- trigger_text here silently broke every procedural insert.
+        trigger TEXT NOT NULL,
         steps TEXT NOT NULL DEFAULT '[]',
         tools TEXT NOT NULL DEFAULT '[]',
         outcome TEXT NOT NULL,

--- a/packages/adapters/sqlite/src/index.ts
+++ b/packages/adapters/sqlite/src/index.ts
@@ -5,11 +5,13 @@
  * Zero-config, file-based. Perfect for development, testing, and single-user deployments.
  *
  * Uses better-sqlite3 for synchronous, fast SQLite access.
- * Translates PostgreSQL-style $1/$2 placeholders to SQLite ? placeholders.
+ * Translates PostgreSQL-style $1/$2 placeholders to SQLite ?1/?2 placeholders.
  *
- * NOTE: This adapter does NOT support pgvector embedding operations.
- * For embedding-based search, use the PostgreSQL adapter.
- * SQLite layers will fall back to non-vector retrieval (recency, keyword match).
+ * Embedding search: pgvector's `<=>` operator is rewritten to a cosine-distance
+ * UDF (zb_cosine_dist) over the JSON-array embeddings this adapter stores, so
+ * semantic/episodic/procedural similarity search works on SQLite. It is a full
+ * scan per query (no ANN index) — fine for development, testing and single-user
+ * data volumes; use the PostgreSQL adapter for large production workloads.
  */
 import Database from 'better-sqlite3';
 import type { StorageAdapter, QueryResult } from '@zensation/core';
@@ -33,9 +35,12 @@ export interface SqliteAdapterConfig {
 
 /**
  * Translate PostgreSQL-style parameterized queries to SQLite.
- * - $1, $2, $3 → ?, ?, ?
+ * - $1, $2, $3 → ?1, ?2, ?3 (numbered, so a repeated $1 binds the same value —
+ *   the layers' vector queries use $1 twice with a single parameter)
  * - Remove ::vector casts (not supported in SQLite)
- * - Remove pgvector operators (<=>)
+ * - Rewrite the pgvector distance operator (embedding <=> $1) to the
+ *   zb_cosine_dist() UDF registered on the connection, so similarity search
+ *   works on SQLite instead of producing invalid SQL
  * - Replace gen_random_uuid() with a generated UUID
  * - Replace NOW() with datetime('now')
  * - Remove HNSW/GIN index hints
@@ -43,8 +48,10 @@ export interface SqliteAdapterConfig {
 function translateQuery(sql: string): string {
   let translated = sql;
 
-  // Replace $N parameters with ?
-  translated = translated.replace(/\$\d+/g, '?');
+  // Replace $N parameters with numbered ?N placeholders. Numbered (not anonymous)
+  // is load-bearing: the vector queries reference $1 in both SELECT and ORDER BY
+  // while passing the embedding only once.
+  translated = translated.replace(/\$(\d+)/g, '?$1');
 
   // Remove PostgreSQL type casts (::vector, ::text, etc.)
   translated = translated.replace(/::\w+/g, '');
@@ -59,10 +66,9 @@ function translateQuery(sql: string): string {
   // Replace TIMESTAMPTZ with TEXT (SQLite stores dates as text)
   translated = translated.replace(/\bTIMESTAMPTZ\b/gi, 'TEXT');
 
-  // Remove vector-specific operations (embedding <=> $1)
-  // These queries won't work in SQLite — caller should handle fallback
-  translated = translated.replace(/\bembedding\s*<=>\s*\?/g, '0');
-  translated = translated.replace(/1\s*-\s*\(0\)/g, '0 as score --');
+  // pgvector cosine-distance operator → cosine UDF over the stored JSON-array
+  // embedding. Ascending distance keeps the layers' ORDER BY semantics.
+  translated = translated.replace(/(\w+)\s*<=>\s*(\?\d+)/g, 'zb_cosine_dist($1, $2)');
 
   // Replace ON CONFLICT (label) DO UPDATE with SQLite equivalent
   // SQLite uses the same syntax, so this should work as-is
@@ -72,6 +78,21 @@ function translateQuery(sql: string): string {
   // We'll keep RETURNING for modern SQLite versions
 
   return translated;
+}
+
+/**
+ * Parse an embedding stored as a pgvector-style string ("[0.1,0.2,...]") into
+ * a number array. Returns null for anything that isn't a numeric JSON array.
+ */
+function parseVector(value: unknown): number[] | null {
+  if (typeof value !== 'string' || value.length < 2) return null;
+  try {
+    const arr: unknown = JSON.parse(value);
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    return arr.every((x): x is number => typeof x === 'number') ? arr : null;
+  } catch {
+    return null;
+  }
 }
 
 export class SqliteAdapter implements StorageAdapter {
@@ -92,6 +113,26 @@ export class SqliteAdapter implements StorageAdapter {
 
     this.db = new Database(filename);
 
+    // Cosine distance over pgvector-style string embeddings ("[0.1,...]").
+    // translateQuery rewrites `embedding <=> $1` to this UDF, giving SQLite real
+    // similarity search. Mismatched/unparsable vectors get max distance (1) so
+    // they sort last instead of crashing the query.
+    this.db.function('zb_cosine_dist', { deterministic: true }, (a: unknown, b: unknown): number => {
+      const va = parseVector(a);
+      const vb = parseVector(b);
+      if (!va || !vb || va.length !== vb.length) return 1;
+      let dot = 0;
+      let na = 0;
+      let nb = 0;
+      for (let i = 0; i < va.length; i++) {
+        dot += va[i] * vb[i];
+        na += va[i] * va[i];
+        nb += vb[i] * vb[i];
+      }
+      const denom = Math.sqrt(na) * Math.sqrt(nb);
+      return denom > 0 ? 1 - dot / denom : 1;
+    });
+
     // Enable WAL mode for better performance
     if (config.walMode !== false) {
       this.db.pragma('journal_mode = WAL');
@@ -111,24 +152,37 @@ export class SqliteAdapter implements StorageAdapter {
     const normalized = translated.trim().toUpperCase();
 
     try {
-      // Filter out null/undefined params that SQLite doesn't handle well
-      const safeParams = (params ?? []).map(p => p === undefined ? null : p);
+      // Coerce params SQLite can't bind: undefined → null, Date → ISO string.
+      // The core layers pass FSRS review times (fsrs_next_review) as Date objects;
+      // better-sqlite3 binds only numbers, strings, bigints, buffers and null.
+      const safeParams = (params ?? []).map(p =>
+        p === undefined ? null : p instanceof Date ? p.toISOString() : p
+      );
+
+      // better-sqlite3 treats numbered placeholders (?1, ?2) as *named* parameters,
+      // so they must be bound via an object keyed "1".."N" — spreading positional
+      // values against them throws "Too many parameter values were provided".
+      const bindArgs: unknown[] = /\?\d+/.test(translated)
+        ? safeParams.length > 0
+          ? [Object.fromEntries(safeParams.map((v, i) => [String(i + 1), v]))]
+          : []
+        : safeParams;
 
       if (normalized.startsWith('SELECT') || normalized.startsWith('WITH')) {
         const stmt = this.db.prepare(translated);
-        const rows = stmt.all(...safeParams) as T[];
+        const rows = stmt.all(...bindArgs) as T[];
         return { rows, rowCount: rows.length };
       }
 
       if (normalized.startsWith('INSERT') && translated.toUpperCase().includes('RETURNING')) {
         const stmt = this.db.prepare(translated);
-        const rows = stmt.all(...safeParams) as T[];
+        const rows = stmt.all(...bindArgs) as T[];
         return { rows, rowCount: rows.length };
       }
 
       if (normalized.startsWith('INSERT') || normalized.startsWith('UPDATE') || normalized.startsWith('DELETE')) {
         const stmt = this.db.prepare(translated);
-        const result = stmt.run(...safeParams);
+        const result = stmt.run(...bindArgs);
         return { rows: [] as T[], rowCount: result.changes };
       }
 


### PR DESCRIPTION
The SQLite adapter failed end to end when driven through `MemoryCoordinator` — nothing in CI exercised the real core↔adapter integration, so several independent defects shipped unseen. Found while integrating the SQLite path end to end; each was reproduced against real data before fixing.

1. **store() threw on every semantic fact** — the layers bind `fsrs_next_review` as a `Date`; better-sqlite3 binds only numbers, strings, bigints, buffers and null. Params now coerce `Date` → ISO string.

2. **recall() was silently empty** — `translateQuery` rewrote `embedding <=> ?` to the constant `0`, producing `ORDER BY 0` (invalid in SQLite); the coordinator swallows per-layer errors, so callers just saw zero results, indistinguishable from an empty memory. The operator is now rewritten to a real cosine-distance UDF (`zb_cosine_dist`) over the stored JSON-array embeddings, so semantic/episodic/procedural similarity search works. It is a full scan per query (no ANN index) — fine for development, testing and single-user volumes; the PostgreSQL adapter remains the path for large production workloads.

3. **Repeated `$1` placeholders broke** — `$N` became anonymous `?`, so the three vector queries (which reference `$1` twice while passing the embedding once) bound the wrong values. They now become numbered `?N`, and since better-sqlite3 treats `?N` as *named* parameters, binding switches to an object keyed `"1".."N"`.

4. **`getRecent(limit, context)` bound its parameters in the wrong order** — same root cause as #3, but worth calling out separately because it hit a plain, non-vector query. `EpisodicMemory.getRecent` builds `WHERE context = $2 ... LIMIT $1`, where `$2` appears *before* `$1` in the SQL text. Positional binding therefore assigned the limit to `context` and the context string to `LIMIT`, failing with `datatype mismatch`. Any context-filtered recall was broken.

5. **`procedural_memories` column was `trigger_text`** but `ProceduralMemory.record()` inserts into `trigger`, so every procedural write failed with *"table procedural_memories has no column named trigger"*. The canonical schema (`adapters/postgres/sql/001_init.sql`) uses `trigger`, and SQLite accepts it as an unquoted column name despite `TRIGGER` being a keyword — so the rename bought nothing and broke the layer. All six tables now diff identical to the canonical schema.

Only #5 surfaced on realistic input: the `type: 'auto'` router sends longer, action-shaped text to the procedural layer, which short smoke-test sentences never reach.

The PostgreSQL adapter is unaffected by all of the above: it passes params straight to `pg` (no rewriting), and `$N`, `<=>` and `Date` binding are all native there.

Adds a coordinator-integration test suite covering every regression above plus UDF correctness (known-vector ordering, unparsable-embedding fallback, repeated-placeholder binding). Each test was verified to fail against the old translation. 33/33 green locally; the 24 existing adapter tests are untouched.