### PR TITLE
chore(release): publish the storage adapters to npm (0.3.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,11 @@ jobs:
       - name: Upgrade npm (trusted publishing needs >= 11.5.1)
         run: npm install -g npm@^11.5.1
       - run: npm install --no-package-lock
+      # Build order matters: algorithms -> core -> adapters (each depends on the previous).
       - run: cd packages/algorithms && npm run build
       - run: cd packages/core && npm run build
+      - run: cd packages/adapters/postgres && npm run build
+      - run: cd packages/adapters/sqlite && npm run build
       # Auth is via OIDC trusted publishing configured on npmjs.com (no NPM_TOKEN);
       # provenance attestations are generated automatically.
       # Idempotent: only publish a version that is not already on the registry,
@@ -92,6 +95,24 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           if npm view "@zensation/core@$VERSION" version >/dev/null 2>&1; then
             echo "@zensation/core@$VERSION already on npm — skipping"
+          else
+            npm publish --access public
+          fi
+      - name: Publish adapter-postgres (skip if already published)
+        run: |
+          cd packages/adapters/postgres
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@zensation/adapter-postgres@$VERSION" version >/dev/null 2>&1; then
+            echo "@zensation/adapter-postgres@$VERSION already on npm — skipping"
+          else
+            npm publish --access public
+          fi
+      - name: Publish adapter-sqlite (skip if already published)
+        run: |
+          cd packages/adapters/sqlite
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@zensation/adapter-sqlite@$VERSION" version >/dev/null 2>&1; then
+            echo "@zensation/adapter-sqlite@$VERSION already on npm — skipping"
           else
             npm publish --access public
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] — 2026-07-17
+
+### Added
+
+- **`@zensation/adapter-sqlite` and `@zensation/adapter-postgres` are now published to npm** (both `0.1.0`). Until now the README listed them as ready while they existed only in this repository, so anyone following the documented setup could not install the storage layer it described. The release job publishes them alongside `core` and `algorithms`.
+
+### Fixed — `@zensation/adapter-sqlite`
+
+The SQLite path did not work end to end when driven through `MemoryCoordinator`. Nothing in CI exercised the real core↔adapter integration, so five independent defects went unnoticed. Each was reproduced against realistic data before being fixed:
+
+- **`store()` threw on every semantic fact.** The layers bind `fsrs_next_review` as a `Date`, which better-sqlite3 cannot bind. Parameters are now coerced (`Date` → ISO string).
+- **`recall()` returned nothing, silently.** `embedding <=> ?` was rewritten to the constant `0`, producing `ORDER BY 0` — invalid in SQLite. The coordinator swallows per-layer errors, so callers saw an empty result indistinguishable from an empty memory. The operator now maps to a real cosine-distance function (`zb_cosine_dist`) over the stored embeddings, so similarity search works. It scans linearly (no ANN index): suitable for development, tests and single-user data; use the PostgreSQL adapter for large workloads.
+- **Repeated `$1` placeholders bound the wrong values**, breaking all three vector queries. `$N` now maps to numbered `?N` with object binding.
+- **`EpisodicMemory.getRecent(limit, context)` swapped its parameters.** Its query places `$2` before `$1`, so positional binding assigned the limit to `context` and the context to `LIMIT`. Every context-filtered recall failed.
+- **`procedural_memories` used a `trigger_text` column** while the layer inserts into `trigger`, so every procedural write failed. The column now matches the canonical schema; all six tables are identical to it.
+
+Adds a coordinator↔adapter integration test suite covering each regression, plus distance-function correctness. The PostgreSQL adapter is unaffected: it passes parameters straight to `pg`, where `$N`, `<=>` and date binding are native.
+
 ## [0.3.4] — 2026-06-27
 
 ### Documentation consistency


### PR DESCRIPTION
`@zensation/adapter-sqlite` and `@zensation/adapter-postgres` are listed as ready in the README, but neither has ever been published — only `core` and `algorithms` are on npm. Anyone following the documented setup cannot install the storage layer the docs describe.

**What this changes**

- The tag-triggered `publish` job now builds and publishes both adapters alongside `core` and `algorithms`, using the same idempotent *skip-if-already-published* pattern, in dependency order (`algorithms` → `core` → adapters).
- `CHANGELOG.md` records the `0.3.5` release: the adapter publication plus the five SQLite fixes from #22.

**First publish is manual, once**

npm cannot configure trusted publishing for a package that does not yet exist ([npm/cli#8544](https://github.com/npm/cli/issues/8544)) — unlike PyPI, the settings page is per-package and requires the package to be on the registry. So `0.1.0` of each adapter has to be published once by hand; the trusted publisher is configured afterwards, and every release after that runs through this job via OIDC with provenance, with no token stored anywhere.

Verification after publishing is a clean-room install from the registry (`npm i @zensation/core @zensation/adapter-sqlite`, then a store/recall round-trip) — the path a new user actually takes.