### PR TITLE
chore(release): 0.4.0 — require Node 22, adopt better-sqlite3 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-08-04
+
+**Compatibility-only release. No runtime code changed** — `packages/*/src` is byte-identical to `0.3.5`. This release exists to publish a narrower, and finally honest, platform requirement.
+
+Package versions move independently: `@zensation/algorithms` `0.3.4 → 0.4.0`, `@zensation/core` `0.2.2 → 0.3.0`, `@zensation/adapter-sqlite` and `@zensation/adapter-postgres` `0.1.0 → 0.2.0`.
+
+### Changed — BREAKING: Node.js 22 or newer is now required
+
+`engines.node` moves from `>=18` to `>=22` in all four published packages.
+
+**The previous `>=18` was never accurate.** `@zensation/adapter-sqlite@0.1.0` depended on `better-sqlite3@^12`, which itself declares `20.x || 22.x || 23.x || 24.x || 25.x || 26.x` — so the effective floor was already **20**, and a Node 18 install would fail on the transitive dependency while our own metadata claimed support. The real change for users is therefore **20 → 22**, not 18 → 22. Node 18 and 20 have both reached end of life.
+
+Under semver, a breaking change in the `0.y.z` range is expressed by the **minor**, and this is deliberate: a `^0.3.4` or `^0.1.0` range does **not** match the new versions, so existing installations on Node 20 are never upgraded into a broken state automatically. Opting in is an explicit act.
+
+**Migration:** upgrade to Node 22 LTS or newer, then bump the ranges — `@zensation/algorithms` to `^0.4.0`, `@zensation/core` to `^0.3.0`, either adapter to `^0.2.0`. Nothing else has to change: no import paths, no APIs, no configuration. Staying on `0.3.x` / `0.1.x` remains valid on Node 20; those versions are unaffected by this release and are not being removed.
+
+### Changed — `@zensation/adapter-sqlite`: `better-sqlite3` 12 → 13
+
+Version 13 is built on **N-API**, so its prebuilt binaries are ABI-independent and install cleanly across current and future Node releases; the version 12 line required a matching prebuild per Node ABI and was the reason the floor could not be stated honestly before. `better-sqlite3@13` itself requires Node `>=22`, which is what forces the baseline above. No adapter API changed.
+
+### Changed — peer ranges widened
+
+Both adapters previously declared `peerDependencies: { "@zensation/core": "^0.2.0" }`, which the move of `core` to `0.3.0` would have broken. The range is now `^0.2.0 || ^0.3.0`: `core`'s public API is unchanged between `0.2.2` and `0.3.0`, so pinning either line is legitimate.
+
 ## [0.3.5] — 2026-07-17
 
 ### Added

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -12,8 +12,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@zensation/algorithms": "^0.3.0",
-    "@zensation/core": "^0.2.2",
+    "@zensation/algorithms": "^0.4.0",
+    "@zensation/core": "^0.3.0",
     "tsx": "^4.23.1"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
       "name": "zenbrain-playground",
       "version": "0.1.0",
       "dependencies": {
-        "@zensation/algorithms": "^0.3.0",
-        "@zensation/core": "^0.2.2",
+        "@zensation/algorithms": "^0.4.0",
+        "@zensation/core": "^0.3.0",
         "tsx": "^4.23.1"
       },
       "devDependencies": {
@@ -2494,7 +2494,7 @@
     },
     "packages/adapters/postgres": {
       "name": "@zensation/adapter-postgres",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "pg": "^8.22.0"
@@ -2508,7 +2508,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@zensation/core": "^0.2.0"
+        "@zensation/core": "^0.2.0 || ^0.3.0"
       }
     },
     "packages/adapters/postgres/node_modules/@vitest/expect": {
@@ -2735,7 +2735,7 @@
     },
     "packages/adapters/sqlite": {
       "name": "@zensation/adapter-sqlite",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^13.0.2"
@@ -2749,7 +2749,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@zensation/core": "^0.2.0"
+        "@zensation/core": "^0.2.0 || ^0.3.0"
       }
     },
     "packages/adapters/sqlite/node_modules/@vitest/expect": {
@@ -2976,7 +2976,7 @@
     },
     "packages/algorithms": {
       "name": "@zensation/algorithms",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.5.1",
@@ -3211,10 +3211,10 @@
     },
     "packages/core": {
       "name": "@zensation/core",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@zensation/algorithms": "^0.3.0"
+        "@zensation/algorithms": "^0.4.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/adapter-postgres",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PostgreSQL + pgvector storage adapter for ZenBrain memory system.",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,7 +47,7 @@
     "pg": "^8.22.0"
   },
   "peerDependencies": {
-    "@zensation/core": "^0.2.0"
+    "@zensation/core": "^0.2.0 || ^0.3.0"
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/adapter-sqlite",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SQLite storage adapter for ZenBrain memory system. Zero-config, file-based, perfect for development and single-user deployments.",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
     "better-sqlite3": "^13.0.2"
   },
   "peerDependencies": {
-    "@zensation/core": "^0.2.0"
+    "@zensation/core": "^0.2.0 || ^0.3.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/packages/algorithms/package.json
+++ b/packages/algorithms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/algorithms",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "ZenBrain's open-source memory algorithm library: 10 core algorithms (FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation, Bayesian confidence, ...) + 10 advanced research modules (vmPFC-FSRS, two-factor Hebbian, simulation-selection sleep, Fiedler-value KG health, Information-Bottleneck budget, Hopfield STM, Personalized PageRank, ...). 20 modules, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/core",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "7-layer memory system for AI agents. Pluggable storage, embeddings, and LLM providers. Built on @zensation/algorithms.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -92,7 +92,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@zensation/algorithms": "^0.3.0"
+    "@zensation/algorithms": "^0.4.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",


### PR DESCRIPTION
Bereitet den ersten Release seit `v0.3.5` (17.07.) vor. **Der Tag ist bewusst nicht gesetzt** — `v*` löst den Publish-Job aus, und eine npm-Version lässt sich nicht zurücknehmen.

## Was hier drin ist

**Kein Laufzeit-Code.** `git log v0.3.5..HEAD -- 'packages/*/src'` ist leer; `packages/*/src` ist bitidentisch zu 0.3.5. Der Release existiert allein, um eine engere — und endlich ehrliche — Plattformanforderung zu veröffentlichen.

| Paket | vorher | nachher |
|---|---|---|
| `@zensation/algorithms` | 0.3.4 | **0.4.0** |
| `@zensation/core` | 0.2.2 | **0.3.0** |
| `@zensation/adapter-sqlite` | 0.1.0 | **0.2.0** |
| `@zensation/adapter-postgres` | 0.1.0 | **0.2.0** |

## Warum Minor und nicht Patch

`engines.node` geht in allen vier Paketen von `>=18` auf `>=22`. Unter semver drückt man ein Breaking im `0.y.z`-Bereich über die **Minor** aus — und das ist hier der Punkt: `^0.3.4` bzw. `^0.1.0` matcht die neuen Versionen **nicht**, also wird keine bestehende Installation auf Node 20 automatisch in einen kaputten Zustand gehoben. Der Umstieg bleibt eine bewusste Handlung.

## Warum `>=18` von Anfang an falsch war

`@zensation/adapter-sqlite@0.1.0` hängt an `better-sqlite3@^12`, und das Paket deklariert selbst `20.x || 22.x || 23.x || 24.x || 25.x || 26.x`. Der **effektive** Boden lag also längst bei **20**, während unsere Metadaten 18 versprachen — eine Node-18-Installation wäre an der transitiven Abhängigkeit gescheitert. Der reale Sprung für Nutzer ist damit **20 → 22**, nicht 18 → 22; beide Linien sind EOL.

`better-sqlite3@13` ist auf **N-API** gebaut: die Prebuilds sind ABI-unabhängig und installieren auch auf künftigen Node-Versionen sauber. Genau das war mit der 12er-Linie nicht möglich.

## Gekoppelte Range-Änderungen — müssen zwingend mitgehen

- `core` → `algorithms` auf `^0.4.0` (echte Abhängigkeit, sonst unauflösbar).
- Beide Adapter peeren auf core als `^0.2.0 || ^0.3.0`. Die öffentliche API von `core` ist zwischen 0.2.2 und 0.3.0 unverändert, deshalb bleibt das Pinnen beider Linien legitim.
- `apps/playground` stand auf `^0.3.0`/`^0.2.2` und hätte sonst **stillschweigend die veröffentlichten Pakete aus der Registry** aufgelöst statt den Workspace zu verlinken. Der neu erzeugte Lockfile hat das sichtbar gemacht.

## Prüfung

Lokal ist nur Node 20 verfügbar, der Boden verlangt jetzt 22 — **Build und Tests laufen deshalb hier in der CI** (`ci.yml` nutzt `node-version: 22`), nicht auf meiner Maschine. Der Lockfile wurde mit `npm install --package-lock-only` neu erzeugt; sein Diff enthält ausschließlich die Versions- und Range-Felder oben, keine transitive Bewegung.

## Nach dem Merge

Der Publish-Job ist **idempotent pro Paket** — er baut alle vier und veröffentlicht nur, was noch nicht auf der Registry liegt. Tag `v0.4.0` setzen löst den Publish aus; das ist der irreversible Schritt und bleibt beim Owner.