### PR TITLE
docs: bring the documentation up to 0.4.0 and state the Node 22 requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] — 2026-08-04
+## [0.4.0] — 2026-08-05
 
 **Compatibility-only release. No runtime code changed** — `packages/*/src` is byte-identical to `0.3.5`. This release exists to publish a narrower, and finally honest, platform requirement.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ identifiers:
 repository-code: "https://github.com/zensation-ai/zenbrain"
 url: "https://github.com/zensation-ai/zenbrain"
 license: Apache-2.0
-version: 0.3.3
-date-released: 2026-05-08
+version: 0.4.0
+date-released: 2026-08-05
 keywords:
   - ai-memory
   - spaced-repetition

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ See [`CHANGELOG.md`](./CHANGELOG.md#030--2026-05-08) for details.
 
 ## Quick Start
 
+> **Requires Node.js 22 or newer** (since `0.4.0`). On Node 20 or older, npm silently installs the last
+> compatible release (`@zensation/algorithms@0.3.4`, `@zensation/core@0.2.2`) instead of the current one —
+> which looks like a broken package but is a platform mismatch. See [CHANGELOG](./CHANGELOG.md#040--2026-08-05).
+
 ```bash
 npm install @zensation/algorithms
 ```
@@ -344,7 +348,7 @@ These aren't toy implementations — ZenBrain's algorithms are extracted from [Z
 
 - **528 tests** (429 algorithms + 99 core), all passing
 - **Zero runtime dependencies** — pure TypeScript, dual ESM + CJS, tree-shakeable subpath exports
-- **Reproducible** — building from this source produces the same 152-file `@zensation/algorithms@0.3.3` tarball published on npm
+- **Reproducible** — building from this source produces the same 152-file `@zensation/algorithms@0.4.0` tarball published on npm
 - **7-layer** memory architecture grounded in published neuroscience
 
 ## Contributing

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,3 +80,18 @@ We prioritize, in this order:
 2. **Simplicity** — APIs should be intuitive, not clever.
 3. **Performance** — optimize for real workloads, not microbenchmarks.
 4. **Compatibility** — avoid breaking existing users; follow semver.
+
+## Compatibility history
+
+Breaking changes are expressed through the **minor** version while the packages are below `1.0.0`, which is
+what semver prescribes for the `0.y.z` range. A `^0.3.4` range therefore does *not* pick up `0.4.0`: existing
+installations never move across a break on their own, and opting in is an explicit act.
+
+| Release | Break | Why |
+|---|---|---|
+| `0.4.0` (2026-08-05) | **Node.js 18/20 dropped, 22+ required** | The declared `>=18` was never accurate — `@zensation/adapter-sqlite` depended on `better-sqlite3@^12`, which itself requires Node 20 or newer, so a Node 18 install failed on a transitive dependency while our metadata claimed support. Adopting `better-sqlite3@13` (N-API, ABI-independent prebuilds) sets the real floor at 22. Both dropped lines are end of life. |
+
+Migration for `0.4.0`: move to Node 22 LTS or newer, then raise the ranges — `@zensation/algorithms` to
+`^0.4.0`, `@zensation/core` to `^0.3.0`, either adapter to `^0.2.0`. No imports, APIs or configuration
+change. Staying on `0.3.x` / `0.1.x` remains valid on Node 20; those versions are unaffected and are not
+being removed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,11 @@
 # Getting Started with ZenBrain
 
+## Requirements
+
+**Node.js 22 or newer.** Every published package declares `engines.node >= 22` since `0.4.0`. On an older
+Node, npm resolves to the last compatible versions instead of failing loudly — so if you end up with
+`@zensation/algorithms@0.3.4` rather than `0.4.0`, check your Node version first.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Reine Dokumentation — **kein Code, keine Versionsfelder in `package.json`.**

## Der teuerste der Fehler zuerst

`CITATION.cff` stand auf **`version: 0.3.3`** / `date-released: 2026-05-08`. Diese Datei lesen **GitHub und Zitierwerkzeuge maschinell** aus — eine veraltete Version wandert in fremde Literaturverzeichnisse und ist dort nicht mehr einzufangen. Jetzt `0.4.0` / `2026-08-05`.

Die CHANGELOG-Überschrift wandert aus demselben Grund von `2026-08-04` auf **`2026-08-05`**: der Commit landete am 4., **öffentlich wurde der Release, als npm ihn am 5. angenommen hat** — und auf dieses Datum bezieht sich eine Zitation.

## 🔴 Die Node-22-Pflicht stand nirgends

Nicht im README, nicht in `docs/getting-started.md`. Wichtig: es stand dort auch **nichts Falsches** wie `>=18` — es stand **überhaupt keine Plattformangabe**.

**Der Fehlermodus ist deshalb still:** Auf Node 20 löst npm nicht mit einem Fehler auf, sondern auf die **letzten kompatiblen Versionen** — `@zensation/algorithms@0.3.4`, `@zensation/core@0.2.2`. Wer das nicht weiß, bekommt ein altes Paket und schließt daraus vernünftigerweise, der Release sei kaputt. Beide Dateien benennen jetzt genau dieses Symptom.

## `docs/ROADMAP.md`: Kompatibilitäts-Historie

`AGENTS.md` schickt Beitragende für die *„compatibility philosophy"* dorthin — und die Datei endete bei **v0.3**, ohne den einzigen echten Bruch des Projekts zu erwähnen. Der neue Abschnitt hält fest:

- **warum `>=18` nie zutraf:** `@zensation/adapter-sqlite` hing an `better-sqlite3@^12`, das selbst Node 20+ verlangt — eine Node-18-Installation scheiterte also an einer transitiven Abhängigkeit, während unsere eigenen Metadaten Unterstützung behaupteten;
- **warum der Bruch über die Minor läuft** (semver für den `0.y.z`-Bereich): `^0.3.4` greift `0.4.0` nicht, bestehende Installationen wandern nie von allein über einen Bruch;
- die **Migration**.

## Gegengeprüft, nicht übernommen

Das Reproduzierbarkeits-Versprechen im README nannte den **0.3.3**-Tarball. Vor der Änderung an der Registry nachgesehen: `@zensation/algorithms@0.4.0` liefert **weiterhin 152 Dateien** (`npm view … dist.fileCount`). Es bewegt sich also nur die Version, und das Versprechen bleibt nachrechenbar — es richtet sich an genau die Leser, die nachrechnen.

## Nicht geändert

Die Statustabelle markiert beide Adapter als „Published". Das war zwei Tage lang formal richtig und praktisch irreführend (0.1.0 lag auf npm, war aber mit `core@0.3.0` nicht installierbar). **Seit heute stimmt es wieder** — beide Adapter liegen als `0.2.0` mit Peer-Range `^0.2.0 || ^0.3.0` auf npm, die Installation läuft durch. Deshalb kein „Known issue"-Hinweis mehr nötig.