### PR TITLE
chore: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## What this changes
+
+A short description of the change and why it is needed.
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change — requires a minor bump in the `0.y.z` range, see [CHANGELOG](../blob/main/CHANGELOG.md)
+- [ ] Documentation only
+- [ ] Build, CI or dependencies
+
+## Affected packages
+
+- [ ] `@zensation/algorithms`
+- [ ] `@zensation/core`
+- [ ] `@zensation/adapter-sqlite`
+- [ ] `@zensation/adapter-postgres`
+- [ ] None (docs, CI, repository files)
+
+## Verification
+
+How this was checked. Tests that only exercise mocks or toy data do not establish that the real path works — say which one this is.
+
+- [ ] `pnpm test` passes locally
+- [ ] New or updated tests cover the change
+- [ ] Verified against a real adapter (SQLite file or PostgreSQL instance), not only mocks
+- [ ] Not applicable — explain below
+
+## Notes for reviewers
+
+Anything non-obvious: trade-offs, follow-up work, or parts you are unsure about.


### PR DESCRIPTION
The repo has issue templates but no PR template.

The **Verification** section asks explicitly whether a change was checked against a real adapter rather than only mocks. That is not boilerplate: it is exactly the gap that let **five independent SQLite defects** ship before `0.3.5` — nothing in CI exercised the real core↔adapter integration, and `recall()` returned an empty result that was indistinguishable from an empty memory.

It also carries a reminder that a breaking change in the `0.y.z` range is expressed by the **minor**, which is the convention `0.4.0` follows.