### PR TITLE
fix: der Discord-Einladungslink ist tot — GitHub Discussions statt dessen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,9 +164,9 @@ export class MyLayer {
 
 ## Getting Help
 
-- **Discord**: [Join our community](https://discord.gg/YKVTHaXK)
-- **GitHub Issues**: For bugs and feature requests
-- **Discussions**: For questions and ideas
+- **GitHub Discussions**: [Questions, ideas and show-and-tell](https://github.com/zensation-ai/zenbrain/discussions)
+- **GitHub Issues**: [Bugs and feature requests](https://github.com/zensation-ai/zenbrain/issues)
+- **Email**: open-source@zensation.ai
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://arxiv.org/abs/2604.23878"><img src="https://img.shields.io/badge/arXiv-2604.23878-b31b1b.svg" alt="arXiv"></a>
   <a href="https://orcid.org/0009-0001-1793-012X"><img src="https://img.shields.io/badge/ORCID-0009--0001--1793--012X-A6CE39?logo=orcid&logoColor=white" alt="ORCID"></a>
   <a href="https://huggingface.co/zensation-ai/zenbrain"><img src="https://img.shields.io/badge/%F0%9F%A4%97_HuggingFace-Model_Card-yellow" alt="HuggingFace"></a>
-  <a href="https://discord.gg/YKVTHaXK"><img src="https://img.shields.io/discord/1485937855447695443?color=7289da&label=Discord&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/zensation-ai/zenbrain/discussions"><img src="https://img.shields.io/badge/Discussions-ask%20a%20question-5865F2?logo=github" alt="GitHub Discussions"></a>
   <a href="https://x.com/zensationai"><img src="https://img.shields.io/twitter/follow/zensationai?style=social" alt="Follow on X"></a>
 </p>
 
@@ -395,7 +395,7 @@ If you use ZenBrain in academic work, please cite:
 
 ## Community
 
-- **Discord**: [ZenBrain Community](https://discord.gg/YKVTHaXK) — help, show-and-tell, feature requests
+- **GitHub Discussions**: [Ask a question, show what you built](https://github.com/zensation-ai/zenbrain/discussions) — help, show-and-tell, feature requests
 - **Twitter/X**: [@zensationai](https://x.com/zensationai) — updates, launches, AI memory discussions
 - **GitHub Issues**: [Bug reports & feature requests](https://github.com/zensation-ai/zenbrain/issues)
 - **Email**: open-source@zensation.ai

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,4 +126,4 @@ import { getRetrievability } from '@zensation/algorithms/ebbinghaus';
 - [Architecture Overview](./architecture.md) — understand the 7-layer design
 - [API Reference](https://www.npmjs.com/package/@zensation/algorithms) — full function signatures
 - [Playground](../apps/playground/) — interactive demo
-- [Discord](https://discord.gg/YKVTHaXK) — get help from the community
+- [GitHub Discussions](https://github.com/zensation-ai/zenbrain/discussions) — get help from the community


### PR DESCRIPTION
## Der Befund

`discord.gg/YKVTHaXK` löst nicht mehr auf. **An zwei Quellen bestätigt:**

- Discords API: `{"message": "Unknown Invite", "code": 10006}`
- Im Browser gerendert: **„Invite Invalid — This invite may be expired, or you might not have permission to join."**

*(Die HTML-Seite liefert trotzdem HTTP 200 — ein reiner Statuscode-Test hätte den Defekt nicht gefunden.)*

Der Link stand an **drei Stellen** in diesem Repo, darunter in der **Badge-Zeile** und im **Community-Abschnitt** des README. Die prominenteste Community-Aufforderung des Projekts führte ins Leere.

**Der Badge war doppelt kaputt:** er rendert `widget disabled`, weil er ein Server-Widget abfragt, das in Discord ausgeschaltet ist. Am SVG gemessen, nicht vermutet.

## Die Lösung

**GitHub Discussions ist auf diesem Repo bereits aktiviert** — sechs Kategorien, Seite liefert 200. Es ersetzt Discord an allen drei Stellen. Nichts Neues zu pflegen, und der Link kann nicht ablaufen.

`CONTRIBUTING.md` führte Discussions schon direkt unter Discord auf, aber **ohne Link**; dieser Eintrag ist jetzt der verlinkte, und die E-Mail-Adresse kam dazu.

Der Badge zeigt bewusst **„ask a question"** statt der Beitragszahl — die läge bei „1 total", und eine kleine Zahl zu bewerben hilft niemandem.

## Nicht angefasst

Der Discord-Server bleibt bestehen. Wenn er ein aktiver Kanal wird, kommt der Badge in einem Commit zurück — dann mit einer **unbefristeten** Einladung, denn genau daran ist es hier gescheitert.

## Verifiziert

- `grep -i discord` über `README.md`, `CONTRIBUTING.md` und `docs/`: **keine Treffer mehr**
- Ersatz-Badge gerendert und gegengelesen · Discussions-URL: HTTP 200
- Diff: **6 Zeilen ersetzt**, kein Code berührt