### PR TITLE
docs(readme): fix two badges that render broken, and a stale version pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
   <a href="https://github.com/zensation-ai/zenbrain/actions/workflows/ci.yml"><img src="https://github.com/zensation-ai/zenbrain/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/zensation-ai/zenbrain/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.7+-blue.svg" alt="TypeScript"></a>
-  <a href="#"><img src="https://img.shields.io/badge/dependencies-0-brightgreen.svg" alt="Zero Dependencies"></a>
+  <img src="https://img.shields.io/badge/dependencies-0-brightgreen.svg" alt="Zero Dependencies">
   <a href="https://doi.org/10.5281/zenodo.19353663"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19353663.svg" alt="DOI"></a>
   <a href="https://arxiv.org/abs/2604.23878"><img src="https://img.shields.io/badge/arXiv-2604.23878-b31b1b.svg" alt="arXiv"></a>
   <a href="https://orcid.org/0009-0001-1793-012X"><img src="https://img.shields.io/badge/ORCID-0009--0001--1793--012X-A6CE39?logo=orcid&logoColor=white" alt="ORCID"></a>
   <a href="https://huggingface.co/zensation-ai/zenbrain"><img src="https://img.shields.io/badge/%F0%9F%A4%97_HuggingFace-Model_Card-yellow" alt="HuggingFace"></a>
   <a href="https://github.com/zensation-ai/zenbrain/discussions"><img src="https://img.shields.io/badge/Discussions-ask%20a%20question-5865F2?logo=github" alt="GitHub Discussions"></a>
-  <a href="https://x.com/zensationai"><img src="https://img.shields.io/twitter/follow/zensationai?style=social" alt="Follow on X"></a>
+  <a href="https://x.com/zensationai"><img src="https://img.shields.io/badge/X-%40zensationai-000000?logo=x&logoColor=white" alt="Follow on X"></a>
 </p>
 
 ---
@@ -88,9 +88,9 @@ ZenBrain brings these mechanisms to AI agents:
 | Self-Hosted | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 
-### Advanced algorithms (v0.3.0, May 2026)
+### Advanced algorithms (since v0.3.0, May 2026)
 
-On top of the 10 core algorithms above, `@zensation/algorithms@0.3.0` ships 10 advanced algorithms grounded in recent neuroscience and ML research. Each is exposed as its own sub-path (`@zensation/algorithms/<name>`) and remains zero-dependency:
+On top of the 10 core algorithms above, `@zensation/algorithms` ships 10 advanced algorithms grounded in recent neuroscience and ML research. Each is exposed as its own sub-path (`@zensation/algorithms/<name>`) and remains zero-dependency:
 
 - **`fsrs-vmPFC`** — Prediction-Error coupled FSRS
 - **`hebbian-two-factor`** — Two-Factor synaptic consolidation


### PR DESCRIPTION
Part of a claim-by-claim sweep across the organisation's public READMEs — the same pass the website got in [KI-AB#559](https://github.com/Alexander-Bering/KI-AB/pull/559). This README came through it in very good shape; three cosmetic defects are all that is left.

| | Before | After |
|---|---|---|
| X badge | `shields.io/twitter/follow/zensationai` → renders `Follow @zensationai:` with an **empty** count, because X closed the public follower API | static `X · @zensationai` badge, same link |
| Zero-dependencies badge | wrapped in `<a href="#">` — a link to nowhere | plain image, no anchor |
| Advanced algorithms | "`@zensation/algorithms@0.3.0` ships 10 advanced algorithms" in the present tense, while 0.4.0 is current | "since v0.3.0" — the version marks when they arrived, not what to install |

## Everything else was verified and is correct

Measured, not assumed:

- **`528 tests (429 algorithms + 99 core), all passing`** — verified by running both suites: algorithms **429 passed**, core **99 passed**. My first static count said 392 for algorithms; the gap is `it.each` expansion, which a static count cannot see. The README is right and the counting method was wrong.
- **`the same 152-file @zensation/algorithms@0.4.0 tarball published on npm`** — the npm registry reports `fileCount: 152` for 0.4.0. Exact.
- **All four packages listed as Published** — `algorithms` 0.4.0, `core` 0.3.0, `adapter-postgres` 0.2.0, `adapter-sqlite` 0.2.0, all Apache-2.0, all pointing at this repository.
- **`Requires Node.js 22 or newer`** — CI matrix is 22 / 24 / 26.
- **Every relative link** — `CHANGELOG.md` (both anchors resolve to real headings), all four `packages/*`, all five `docs/*`, `CONTRIBUTING.md`, `LICENSE`, `docs/demo.gif`.
- **Every external link** — 33 targets, all reachable.

## One finding withdrawn before it reached this PR

I was about to report that the Contributing block documents `npm test` before `npm run build`, since running `vitest` inside `packages/core` before a build fails with `Cannot find package '@zensation/algorithms/fsrs'`. `turbo.json` declares `test: dependsOn ["build"]` and `build: dependsOn ["^build"]`, so `npm test` at the root builds first on its own. The documented order is correct; my method had bypassed turbo.

Likewise, a local `npm run build` failure on the adapters was my Node 20 environment, not this repo — CI is green on 22 / 24 / 26.