### PR TITLE
docs(readme): surface the five runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ const nextInterval = computeAdaptiveFSRSInterval(14, pe);
 
 Each advanced algorithm has its own sub-path (`@zensation/algorithms/spectral-health`, `@zensation/algorithms/ib-budget`, …). All zero dependencies.
 
+## Runnable examples
+
+Five self-contained examples live in [`examples/`](./examples):
+
+| Example | Shows |
+|---|---|
+| [`basic-chatbot.ts`](./examples/basic-chatbot.ts) | Working Memory + Short-Term Memory for conversation context — no SDK needed |
+| [`with-claude.ts`](./examples/with-claude.ts) | An Anthropic Claude assistant that remembers across conversations |
+| [`with-langchain.ts`](./examples/with-langchain.ts) | ZenBrain as the memory backend of a LangChain agent |
+| [`with-crewai.ts`](./examples/with-crewai.ts) | Multiple agents sharing Working Memory, with Hebbian strengthening |
+| [`with-vercel-ai.ts`](./examples/with-vercel-ai.ts) | A memory-aware system prompt for the Vercel AI SDK `streamText` pattern |
+
+```bash
+npx tsx examples/basic-chatbot.ts
+```
+
+The integration examples additionally need their respective SDK installed. Want a LlamaIndex.TS or Mastra example? Those are open as [good first issues](https://github.com/zensation-ai/zenbrain/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
 ## The Science Behind It
 
 ### 7-Layer Memory Architecture


### PR DESCRIPTION
`examples/` ships five runnable examples (`basic-chatbot`, `with-claude`, `with-langchain`, `with-crewai`, `with-vercel-ai`) — and the README mentions the folder **zero** times. At the same time, [#17](https://github.com/zensation-ai/zenbrain/issues/17) and [#18](https://github.com/zensation-ai/zenbrain/issues/18) ask contributors for *more* integration examples. The repo was requesting additions to a collection nobody could see.

Adds a compact `## Runnable examples` section between Quick Start and The Science Behind It:

- one table row per example, description taken from the file's **own header comment** (nothing invented)
- the run command from `examples/package.json` (`npx tsx examples/basic-chatbot.ts`)
- a closing pointer at #17/#18 for readers who want to add the missing integrations

CI note: `basic-chatbot` is what the CI smoke-test step already runs, so the "no SDK needed" row is CI-proven on every push.