### PR TITLE
docs: finish the 0.4.0 paperwork the FAQ entry exposed

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,15 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 0.3.x   | Yes       |
-| 0.2.x   | Security fixes only |
-| < 0.2   | No        |
+These are **release lines** — the `v*` tags and [`CHANGELOG.md`](CHANGELOG.md) entries — not individual
+package versions. One release publishes several packages at different numbers, so `0.4.0` ships
+`@zensation/algorithms@0.4.0` alongside `@zensation/core@0.3.0` and both adapters at `0.2.0`.
+
+| Release | Supported | |
+|---------|-----------|---|
+| 0.4.x   | Yes | Current line. Requires Node.js 22 or newer. |
+| 0.3.x   | Security fixes only | Last line that runs on Node.js 20 — see [compatibility history](docs/ROADMAP.md#compatibility-history). |
+| < 0.3   | No | |
 
 ## Reporting a Vulnerability
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,7 +24,7 @@ ZenBrain has deeper scientific grounding — every algorithm cites its neuroscie
 
 The algorithms and core layers are extracted from ZenAI, a production AI platform, and run against real users and real data. The published packages ship 528 tests (429 algorithms + 99 core), all passing.
 
-That said, ZenBrain is at v0.3 — expect API changes before v1.0. We follow semver.
+That said, ZenBrain is still pre-1.0 — expect API changes before v1.0. We follow semver, and the [CHANGELOG](../CHANGELOG.md) records what changed in each release.
 
 ### What license is ZenBrain under?
 
@@ -48,6 +48,7 @@ node -v
 npm ls @zensation/algorithms
 ```
 
+The requirement arrived in [0.4.0](../CHANGELOG.md#040--2026-08-05), the only breaking change the project has shipped so far.
 
 ---
 


### PR DESCRIPTION
Follow-up to #42, which I merged as-is rather than sending a first-time contributor back for cosmetics.

**The two things I owed that PR**
- the CHANGELOG link requested in #38
- the stray blank line before the section rule

**The thing #42 made visible.** Its new entry landed three lines under `That said, ZenBrain is at v0.3` — stale since 0.4.0 shipped on 2026-08-05, and the sentence is now version-free so it cannot go stale a third time.

**The thing I found looking for the first.** `SECURITY.md` listed `0.3.x` as the supported line and did not mention `0.4.x` at all: the security policy said the release npm actually serves is unsupported. The `Version` column was ambiguous on top of that — one release publishes packages at four different numbers, so `< 0.2 | No` read as excluding `@zensation/adapter-sqlite@0.2.0`, which is current. The table now says *release line* and names the numbers.

`0.3.x` keeps "security fixes only" instead of dropping off: [docs/ROADMAP.md](https://github.com/zensation-ai/zenbrain/blob/main/docs/ROADMAP.md#compatibility-history) states it remains valid on Node 20 and is not being removed. No policy was invented here, only the existing table shifted by one release.

**Checked before pushing:** the `#040--2026-08-05` and `#compatibility-history` anchors both resolve on the rendered pages; the "only breaking change so far" claim matches the single row in the compatibility table; zero double blank lines remain in `FAQ.md` (counter-checked against a file that has one, so the check isn't vacuous).
