### PR TITLE
docs: recipes.md + LlamaIndex.TS and Mastra integration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ These aren't toy implementations — ZenBrain's algorithms are extracted from [Z
 
 We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
-**Resources:** [API Reference](./docs/api-reference.md) | [Architecture](./docs/architecture.md) | [Benchmarks](./docs/benchmarks.md) | [FAQ](./docs/FAQ.md) | [Roadmap](./docs/ROADMAP.md)
+**Resources:** [API Reference](./docs/api-reference.md) | [Recipes](./docs/recipes.md) | [Architecture](./docs/architecture.md) | [Benchmarks](./docs/benchmarks.md) | [FAQ](./docs/FAQ.md) | [Roadmap](./docs/ROADMAP.md)
 
 ```bash
 # Clone the repo

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,195 @@
+# Recipes
+
+Short, copy-pasteable patterns. Each one is a few lines plus the reasoning behind it.
+
+For complete runnable programs see [`examples/`](../examples); for the full surface see the
+[API Reference](./api-reference.md). Everything below uses only exported API.
+
+> **Node.js 22+** — every published package declares `engines.node >= 22` since `0.4.0`.
+
+---
+
+## 1. Which layer should this fact go to?
+
+`store()` defaults to `type: 'auto'`, which routes for you. Override it when you already know the
+shape of what you are writing, because the three layers answer three different questions:
+
+| Layer | Answers | Write it when |
+|---|---|---|
+| `semantic` | *What is true?* | The statement stays true independently of when it was learned |
+| `episodic` | *What happened?* | The event, its time, and its context are the point |
+| `procedural` | *How is this done?* | You have an ordered sequence that can be replayed |
+
+```ts
+// A fact: true regardless of when it was said
+await memory.store('The production database is eu-central-1', { type: 'fact' });
+
+// An event: the timestamp and context carry the meaning
+await memory.store('Deploy 4.2 failed on the migration step', {
+  type: 'episode',
+  context: 'work',
+});
+
+// A procedure: the steps ARE the content
+await memory.store('Roll back a failed migration', {
+  type: 'procedure',
+  steps: ['Stop writers', 'Restore snapshot', 'Replay WAL', 'Re-enable writers'],
+  tools: ['psql', 'pg_restore'],
+  outcome: 'Database back at the pre-deploy state',
+});
+```
+
+**Rule of thumb:** if you would still write the sentence a year from now without changing a word,
+it is semantic. If it needs "on Tuesday" to make sense, it is episodic.
+
+When in doubt, leave `type: 'auto'`. A wrong explicit type is worse than letting the router decide.
+
+---
+
+## 2. `consolidate()` on a schedule or on demand?
+
+`consolidate()` promotes short-term material into long-term layers, decays what was not reinforced,
+and prunes what fell below threshold. It returns what it did:
+
+```ts
+const { promoted, decayed, pruned } = await memory.consolidate();
+```
+
+It is modelled on sleep consolidation, so the useful mental picture is the same: run it **between**
+sessions, not during one.
+
+```ts
+// Scheduled: a long-running assistant, consolidating while nobody is talking to it
+setInterval(() => void memory.consolidate(), 60 * 60 * 1000); // hourly
+
+// On demand: a request-scoped worker, consolidating at the end of a conversation
+async function endSession() {
+  const result = await memory.consolidate();
+  await memory.close();
+  return result;
+}
+```
+
+**Pick scheduled** when the process outlives individual conversations and idle time exists.
+**Pick on demand** when the process is short-lived — a serverless handler that never consolidates
+throws away everything it learned.
+
+⚠️ Do not call it inside a turn to "make the agent smarter mid-conversation". Promotion and decay
+change what `recall()` returns, so a mid-turn call can move the ground under a reply that is already
+half-written. `decay()` alone is cheaper if all you want is to expire stale entries:
+
+```ts
+const { removed } = memory.decay(); // synchronous, no promotion
+```
+
+---
+
+## 3. Tuning review intervals for your use case
+
+`scheduleNextReview()` takes the retention you want to hold at the moment of review. The default is
+`TARGET_RETENTION` (0.9): review just before there is a 10 % chance of having forgotten.
+
+```ts
+import { scheduleNextReview, TARGET_RETENTION } from '@zensation/algorithms';
+
+// Default: review at 90 % predicted retention
+state.nextReview = scheduleNextReview(state);
+
+// Support bot: a wrong answer is expensive, so review earlier and more often
+state.nextReview = scheduleNextReview(state, 0.95);
+
+// Long-running personal assistant: tolerate more forgetting, review far less
+state.nextReview = scheduleNextReview(state, 0.8);
+```
+
+**Higher target ⇒ shorter intervals ⇒ more reviews.** The trade is review cost against error rate,
+and it is genuinely a trade: pushing toward 0.99 produces a review queue nobody works through, which
+is worse than 0.9 honestly maintained.
+
+Reviews go through the coordinator, so you rarely touch FSRS state by hand:
+
+```ts
+const due = await memory.getReviewQueue(10);
+for (const item of due) {
+  const grade = await askUser(item.content); // 1..5
+  await memory.recordReview(item.id, grade);
+}
+```
+
+---
+
+## 4. Combining Hebbian edge weights with your own relevance score
+
+`recall()` already scores results. When you have domain knowledge it cannot have — a support ticket
+is more relevant while its ticket is open — blend rather than replace, and keep the two factors
+visible:
+
+```ts
+import { getImportance, hebbianUpdateTwoFactor, type TwoFactorEdge } from '@zensation/algorithms';
+
+// Co-activation strengthens the edge; variance shrinks as it matures
+edge = hebbianUpdateTwoFactor(edge, tagScore, activationProduct);
+
+const results = await memory.recall('deployment problems', { limit: 20 });
+
+const ranked = results
+  .map(r => {
+    const edge = edges.get(r.content);
+    // getImportance() = 1 / variance: high for edges seen often and consistently
+    const hebbian = edge ? Math.min(getImportance(edge) / 10, 1) : 0;
+    return { ...r, blended: 0.6 * r.score + 0.3 * hebbian + 0.1 * myDomainScore(r) };
+  })
+  .sort((a, b) => b.blended - a.blended)
+  .slice(0, 5);
+```
+
+**Why `getImportance()` and not `edge.weight`:** weight says how strong the association is, variance
+says how *settled* it is. A brand-new edge can reach a high weight from a single coincidence;
+importance (`1 / variance`) only rises once the association has survived repetition. Ranking on
+weight alone surfaces flukes.
+
+**Keep the coefficients summing to 1** and keep `r.score` dominant. If your own term outweighs it,
+you have built a retrieval system and are using this one as a cache.
+
+---
+
+## 5. Domain-specific facts that must not fade
+
+Emotional weight feeds both the initial FSRS state and the decay rate — `computeEmotionalWeight()`
+returns `decayMultiplier`, where values above 1 mean slower decay. The automatic tagger reads
+language, so it cannot know that in your domain "allergy" outranks any word with an exclamation mark:
+
+```ts
+import { tagEmotion, computeEmotionalWeight, initFromDecayClass } from '@zensation/algorithms';
+
+const CRITICAL = /\b(allergy|contraindicat|dosage|safety)\b/i;
+
+function weightFor(content: string): number {
+  const { consolidationWeight } = computeEmotionalWeight(tagEmotion(content));
+  // Domain override: floor critical facts near the top of the range
+  return CRITICAL.test(content) ? Math.max(consolidationWeight, 0.9) : consolidationWeight;
+}
+
+await memory.store(content, { type: 'fact', emotionalWeight: weightFor(content) });
+
+// Same weight when you build FSRS state directly
+const state = initFromDecayClass('good', weightFor(content));
+```
+
+⚠️ **Use a floor, not a constant.** Writing `emotionalWeight: 1.0` for every domain hit flattens the
+ranking you were trying to sharpen: if everything is critical, the layer can no longer tell you what
+is *most* critical. `Math.max()` keeps the tagger's ordering inside the protected set.
+
+**Do not use this to pin marketing copy.** The mechanism models why emotionally significant events
+consolidate faster; spending it on material that merely *should* be seen means the signal no longer
+means anything when a genuinely important fact arrives.
+
+---
+
+## See also
+
+- [`examples/`](../examples) — complete runnable integrations (LangChain, CrewAI, Vercel AI SDK,
+  LlamaIndex.TS, Mastra, plain Claude)
+- [Architecture](./architecture.md) — how the seven layers relate
+- [API Reference](./api-reference.md) — every exported symbol
+- [FAQ](./FAQ.md)

--- a/examples/with-llamaindex.ts
+++ b/examples/with-llamaindex.ts
@@ -1,0 +1,138 @@
+/**
+ * ZenBrain + LlamaIndex.TS Integration Example
+ *
+ * Shows how to use ZenBrain's MemoryCoordinator as the long-term memory
+ * backend for a LlamaIndex.TS agent. LlamaIndex keeps the short-term
+ * conversation window; ZenBrain decides what is worth keeping beyond it,
+ * and hands back only what is currently retrievable.
+ *
+ * == Where the seam is ==
+ *
+ * LlamaIndex composes memory from *blocks* (`createMemory({ memoryBlocks })`)
+ * and merges short- and long-term content within `tokenLimit`. This example
+ * puts ZenBrain behind a `staticBlock` that is refreshed per turn from
+ * `coordinator.recall()`. That keeps the integration on documented LlamaIndex
+ * API and leaves both sides doing what they are good at:
+ *
+ *   LlamaIndex  -> token budgeting, message adapters, agent loop
+ *   ZenBrain    -> what to remember, what to surface, what to let go
+ *
+ * == Neuroscience Background ==
+ *
+ * This mirrors the split between working memory and long-term storage. The
+ * conversation window is Baddeley's phonological loop: small, recent, and
+ * overwritten constantly. `recall()` is cued retrieval from consolidated
+ * stores — you do not get everything you ever knew, you get what the current
+ * cue makes accessible (Tulving's encoding specificity, 1973).
+ *
+ * The practical consequence is the reason to bother: an agent that pastes its
+ * whole history into context does not remember, it re-reads. Retrieval that
+ * can *fail* is what makes remembering informative.
+ *
+ * Prerequisites:
+ *   npm install @zensation/core @llamaindex/core llamaindex
+ *
+ * Verified against @llamaindex/core 0.6.22 (2026-08-14). Note the import path:
+ * `staticBlock` and `createMemory` live in `@llamaindex/core/memory`, not in the
+ * `llamaindex` umbrella package — some published docs show them imported from
+ * `"llamaindex"`, which does not resolve.
+ *
+ * Run (no API key needed — the demo stops before the model call):
+ *   npx tsx examples/with-llamaindex.ts
+ */
+import { MemoryCoordinator, InMemoryStorage, FakeEmbeddingProvider } from '@zensation/core';
+import { staticBlock } from '@llamaindex/core/memory';
+
+// --- Memory setup ---
+// InMemoryStorage + FakeEmbeddingProvider come from @zensation/core's testing
+// exports, so this file runs with no database and no API key. Swap in
+// @zensation/adapter-sqlite (or -postgres) and a real embedding provider for
+// anything you intend to keep.
+
+const memory = new MemoryCoordinator({
+  storage: new InMemoryStorage(),
+  embedding: new FakeEmbeddingProvider(),
+  contexts: ['personal', 'work', 'learning'],
+});
+
+// --- The bridge: ZenBrain recall -> a LlamaIndex memory block ---
+
+/**
+ * Build the long-term block for one turn.
+ *
+ * Note the `limit`: this is a budget decision, not a search-quality one.
+ * Everything returned here competes for the same `tokenLimit` as the live
+ * conversation, so a generous limit silently evicts recent turns.
+ */
+async function longTermBlock(userInput: string, limit = 5) {
+  const recalled = await memory.recall(userInput, {
+    layers: ['semantic', 'episodic', 'core'],
+    limit,
+    minConfidence: 0.6,
+  });
+
+  if (recalled.length === 0) {
+    // An empty block is a real answer: nothing consolidated matches this cue.
+    return staticBlock({ content: '' });
+  }
+
+  const lines = recalled
+    .sort((a, b) => b.score - a.score)
+    .map(r => `- [${r.layer}] ${r.content}`)
+    .join('\n');
+
+  return staticBlock({ content: `What you remember about this:\n${lines}` });
+}
+
+/** Record a turn in both systems: ZenBrain for consolidation, the return value for the agent. */
+async function recordTurn(role: 'user' | 'assistant', content: string) {
+  memory.addInteraction(role, content);
+  // Only user statements are stored as candidate long-term material. Storing the
+  // assistant's own output would let the agent consolidate its own guesses into
+  // facts — the failure mode that makes long-running agents confidently wrong.
+  if (role === 'user') {
+    await memory.store(content, { type: 'auto', context: 'work' });
+  }
+}
+
+// --- Demo usage ---
+
+async function main() {
+  memory.startSession('llamaindex-demo');
+
+  // Seed a few turns' worth of prior knowledge
+  await recordTurn('user', 'I prefer TypeScript over JavaScript for anything with a team');
+  await recordTurn('user', 'The project deadline is March 30th and it is the hard kind');
+  await recordTurn('user', 'Our production database runs in eu-central-1');
+
+  // A new turn: build the block that will go into the agent's context
+  const question = 'How should I prioritise my work today?';
+  const block = await longTermBlock(question);
+
+  console.log('--- long-term block for this turn ---');
+  console.log(block);
+
+  // Hand it to LlamaIndex. In a real program:
+  //
+  //   import { createMemory, agent } from 'llamaindex';
+  //   const mem = createMemory({ tokenLimit: 40000, memoryBlocks: [block] });
+  //   const workflow = agent({ name: 'assistant', llm, memory: mem });
+  //   const response = await workflow.run(question);
+  //   await recordTurn('assistant', response.data.result);
+  //
+  // Rebuild the block each turn — `recall()` is cue-dependent, so a block built
+  // for the previous question is stale in a way that is easy to miss.
+
+  await recordTurn('user', question);
+
+  // Between sessions, not during one: promote what was reinforced, decay the rest.
+  const { promoted, decayed, pruned } = await memory.consolidate();
+  console.log(`\nconsolidated: ${promoted} promoted, ${decayed} decayed, ${pruned} pruned`);
+
+  const health = await memory.getHealth();
+  console.log('semantic facts:', health.semantic.count, '| due for review:', health.semantic.dueForReview);
+
+  await memory.close();
+}
+
+main().catch(console.error);

--- a/examples/with-mastra.ts
+++ b/examples/with-mastra.ts
@@ -1,0 +1,179 @@
+/**
+ * ZenBrain + Mastra Integration Example
+ *
+ * Shows how to use ZenBrain's MemoryCoordinator as the memory layer behind a
+ * Mastra agent: a Processor records every turn on its way to the model, and the
+ * agent's instructions are rebuilt each turn from what ZenBrain can currently
+ * recall.
+ *
+ * == Where the seam is ==
+ *
+ * Mastra offers two extension points, and this example uses both for the half
+ * each is good at:
+ *
+ *   Processor.processInput  -> the WRITE path. Sees every message, returns them
+ *                              unchanged, and consolidates on the way past.
+ *   dynamic instructions    -> the READ path. Built per turn from recall().
+ *
+ * The write path deliberately does not rewrite messages. A processor that both
+ * observes and rewrites is very hard to debug later, because a wrong answer no
+ * longer tells you whether retrieval or rewriting caused it.
+ *
+ * == Neuroscience Background ==
+ *
+ * Splitting write from read mirrors the difference between encoding and
+ * retrieval, which are not the same operation run backwards. Encoding is
+ * automatic and cheap; retrieval is cue-driven, effortful, and can fail. The
+ * testing effect (Roediger & Karpicke, 2006) is the clearest evidence they are
+ * separate: retrieving a fact strengthens it more than re-reading it does.
+ *
+ * That is why `recordReview()` exists in the read path below rather than the
+ * write path — a fact that was successfully used gets its schedule updated,
+ * which is exactly the asymmetry the effect describes.
+ *
+ * Prerequisites:
+ *   npm install @zensation/core @mastra/core
+ *
+ * Verified against @mastra/core 0.24.9 (2026-08-14). Two details differ from
+ * some published docs: the Processor identity field is `name` (not `id`), and
+ * the message type is `MastraMessageV2` (not `MastraDBMessage`).
+ *
+ * Run (no API key needed — the demo stops before the model call):
+ *   npx tsx examples/with-mastra.ts
+ */
+import { MemoryCoordinator, InMemoryStorage, FakeEmbeddingProvider } from '@zensation/core';
+import type { Processor } from '@mastra/core/processors';
+import type { MastraMessageV2 } from '@mastra/core/agent';
+
+// --- Memory setup ---
+// InMemoryStorage + FakeEmbeddingProvider come from @zensation/core's testing
+// exports, so this file runs with no database and no API key. Swap in
+// @zensation/adapter-sqlite (or -postgres) and a real embedding provider for
+// anything you intend to keep.
+
+const memory = new MemoryCoordinator({
+  storage: new InMemoryStorage(),
+  embedding: new FakeEmbeddingProvider(),
+  contexts: ['personal', 'work', 'learning'],
+});
+
+/** Pull plain text out of a Mastra message without assuming a single part shape. */
+function textOf(message: MastraMessageV2): string {
+  const parts = message.content?.parts ?? [];
+  return parts
+    .filter((p): p is typeof p & { text: string } => p.type === 'text' && 'text' in p)
+    .map(p => p.text)
+    .join(' ')
+    .trim();
+}
+
+// --- Write path: a Processor that records, and changes nothing ---
+
+class ZenBrainRecorder implements Processor {
+  readonly name = 'zenbrain-recorder';
+
+  async processInput({ messages }: { messages: MastraMessageV2[] }): Promise<MastraMessageV2[]> {
+    for (const message of messages) {
+      const text = textOf(message);
+      if (!text) continue;
+
+      const role = message.role === 'assistant' ? 'assistant' : 'user';
+      memory.addInteraction(role, text);
+
+      // Only user statements become candidate long-term material. Storing the
+      // model's own output would let the agent consolidate its guesses into
+      // facts, which is how long-running agents become confidently wrong.
+      if (role === 'user') {
+        await memory.store(text, { type: 'auto', context: 'work' });
+      }
+    }
+
+    // Returned unchanged on purpose — see "Where the seam is" above.
+    return messages;
+  }
+}
+
+// --- Read path: instructions rebuilt from recall each turn ---
+
+const BASE_INSTRUCTIONS = 'You are a helpful assistant. Use what you remember, and say so when you do not know.';
+
+async function instructionsFor(userInput: string): Promise<string> {
+  const recalled = await memory.recall(userInput, {
+    layers: ['semantic', 'episodic', 'core'],
+    limit: 5,
+    minConfidence: 0.6,
+  });
+
+  if (recalled.length === 0) {
+    // Retrieval that can come back empty is the point: it tells the model to
+    // ask rather than to invent.
+    return BASE_INSTRUCTIONS;
+  }
+
+  const lines = recalled
+    .sort((a, b) => b.score - a.score)
+    .map(r => `- [${r.layer}] ${r.content}`)
+    .join('\n');
+
+  return `${BASE_INSTRUCTIONS}\n\nWhat you remember about this:\n${lines}`;
+}
+
+// --- Demo usage ---
+
+async function main() {
+  memory.startSession('mastra-demo');
+
+  const recorder = new ZenBrainRecorder();
+
+  // Simulate what Mastra hands a processor on the way to the model.
+  const incoming = [
+    {
+      id: '1',
+      role: 'user',
+      createdAt: new Date(),
+      content: { format: 2, parts: [{ type: 'text', text: 'Our production database runs in eu-central-1' }] },
+    },
+    {
+      id: '2',
+      role: 'user',
+      createdAt: new Date(),
+      content: { format: 2, parts: [{ type: 'text', text: 'The March 30th deadline is the hard kind' }] },
+    },
+  ] as unknown as MastraMessageV2[];
+
+  await recorder.processInput({ messages: incoming });
+
+  const question = 'How should I prioritise my work today?';
+  const instructions = await instructionsFor(question);
+
+  console.log('--- instructions for this turn ---');
+  console.log(instructions);
+
+  // Hand both to Mastra. In a real program:
+  //
+  //   import { Agent } from '@mastra/core/agent';
+  //   const agent = new Agent({
+  //     name: 'assistant',
+  //     model,
+  //     instructions: async ({ runtimeContext }) => instructionsFor(currentInput(runtimeContext)),
+  //     inputProcessors: [recorder],
+  //   });
+  //   const result = await agent.generate(question);
+  //
+  // Rebuild instructions per turn — recall() is cue-dependent, so instructions
+  // built for the previous question are stale in a way that is easy to miss.
+
+  // A fact that was actually used gets its review schedule updated (testing effect).
+  const due = await memory.getReviewQueue(3);
+  if (due[0]) {
+    await memory.recordReview(due[0].id, 4);
+    console.log('\nreviewed:', due[0].content);
+  }
+
+  const { promoted, decayed, pruned } = await memory.consolidate();
+  console.log(`consolidated: ${promoted} promoted, ${decayed} decayed, ${pruned} pruned`);
+
+  await memory.close();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Closes #17, closes #18, closes #19.

## What this adds

| File | Issue |
|---|---|
| `docs/recipes.md` | #19 — the five patterns requested, linked from the README Resources line |
| `examples/with-llamaindex.ts` | #17 |
| `examples/with-mastra.ts` | #18 |

Both examples follow the existing self-contained style (`with-langchain.ts` as the template): one runnable file, a header explaining the seam and the cognitive-science background, and **no API key required** — they use the `InMemoryStorage` / `FakeEmbeddingProvider` testing exports and stop before the model call.

## 🔴 Both vendor docs were wrong, and the examples say so

Every third-party symbol was checked against the **shipped package**, not the documentation. In both cases an example written from the published docs would not resolve:

- **LlamaIndex.TS** — `staticBlock` and `createMemory` are **not** in the `llamaindex` umbrella package. They live in **`@llamaindex/core/memory`** (verified against `@llamaindex/core@0.6.22`). Searching `llamaindex@0.12.1` for `staticBlock` returns **0 files**; `createMemory` appears only inside bundled subpackages.
- **Mastra** — the `Processor` identity field is **`name`**, not `id`; the message type is **`MastraMessageV2`**, not `MastraDBMessage`; and **`ProcessInputArgs` does not exist** in `@mastra/core@0.24.9` (0 files). The real signature takes an inline `{ messages, abort, tracingContext? }`.

Each file records the pinned version it was verified against and the discrepancy, so the next reader does not have to re-derive it.

## Verification

- **`recipes.md`:** all 11 cited symbols confirmed as real exports of `@zensation/algorithms` (`TARGET_RETENTION`, `scheduleNextReview`, `getImportance`, `hebbianUpdateTwoFactor`, `TwoFactorEdge`, `tagEmotion`, `computeEmotionalWeight`, `initFromDecayClass`, `getRetrievability`, `updateAfterRecall`, `FSRSState`). Control probe on an invented symbol: 0 hits, so the check is not vacuous.
- **Coordinator API** (`store`, `recall`, `consolidate`, `decay`, `getReviewQueue`, `recordReview`, `getHealth`, `close`) read from `packages/core/src/coordinator.ts`, including the exact option and result shapes.
- **`InMemoryStorage` / `FakeEmbeddingProvider`** confirmed as public exports of `@zensation/core` (`src/index.ts:43`).

## What is NOT verified

**Neither new example is typechecked or run by CI** — deliberately, and identically to the five existing integration examples, whose SDKs the repo does not install. CI's smoke test still runs only `basic-chatbot.ts`. What is verified is that every imported symbol exists at the pinned versions; what is not verified is end-to-end execution against a live model.

## Deliberately left open

**#39** (`examples/README.md`) stays open. It is small, precisely specified, and only six days old — and small, well-specified issues are the ones outside contributors actually take here (#38 was answered by a first-time contributor 58 minutes after it was filed). Removing the last low rung to tidy the list would trade a working entry point for a cosmetic one.