### PR TITLE
fix(issues): replace dead Discord invite with permanent link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,7 +11,7 @@ contact_links:
     url: https://github.com/zensation-ai/zenbrain/discussions
     about: Usage questions, ideas and show-and-tell live in Discussions.
   - name: 🧠 Discord community
-    url: https://discord.gg/YKVTHaXK
+    url: https://discord.gg/GStWXamME7
     about: Chat with other people using ZenBrain.
   - name: 📖 Documentation
     url: https://github.com/zensation-ai/zenbrain/tree/main/docs


### PR DESCRIPTION
The issue chooser (#59) linked `discord.gg/YKVTHaXK`. The Discord API answers **Unknown Invite (10006)** for it — same response as a control probe with an invented code — so the community door in the chooser was dead.

Replacement: `discord.gg/GStWXamME7`, generated as a **permanent** invite (Expire After: Never, Max Uses: No limit) and verified server-side:

```
GET /api/v10/invites/GStWXamME7 -> guild: ZenBrain Community, channel: general, expires_at: null
```

One-line change; grep shows no other occurrence of the dead code in the repo.