### PR TITLE
npm: connect the package surface, gate the zero-dependency claim in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Smoke-test example (basic-chatbot)
         run: npx tsx examples/basic-chatbot.ts
 
+      # The README claims zero runtime dependencies. Prove it against the packed
+      # artifacts on every push, so the claim cannot quietly stop being true between
+      # releases. This step sits inside the required `test` check by design.
+      - name: Verify the zero-dependency claim
+        run: bash scripts/verify-zero-dependencies.sh
+
   publish:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')

--- a/packages/adapters/postgres/README.md
+++ b/packages/adapters/postgres/README.md
@@ -79,3 +79,18 @@ const workMemory = new SemanticMemory({ storage: work });
 ## License
 
 Apache 2.0
+
+## About ZenBrain
+
+ZenBrain is a seven-layer, neuroscience-derived memory architecture for LLM agents, built as
+zero-dependency TypeScript and published under Apache-2.0. On LongMemEval-500 it wins all nine
+head-to-head answer-quality comparisons against Letta, Mem0 and A-Mem (three competitors x three
+LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's binary-judge
+accuracy at 1/106th of the per-query token cost.
+
+- Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+
+License: Apache-2.0

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -28,9 +28,15 @@
   "keywords": [
     "zenbrain",
     "postgres",
+    "postgresql",
     "pgvector",
     "ai-memory",
-    "storage-adapter"
+    "agent-memory",
+    "long-term-memory",
+    "storage-adapter",
+    "vector-search",
+    "llm-memory",
+    "ai-agents"
   ],
   "author": "ZenSation <open-source@zensation.ai>",
   "license": "Apache-2.0",

--- a/packages/adapters/sqlite/README.md
+++ b/packages/adapters/sqlite/README.md
@@ -52,3 +52,18 @@ const storage = new SqliteAdapter({
 ## License
 
 Apache 2.0
+
+## About ZenBrain
+
+ZenBrain is a seven-layer, neuroscience-derived memory architecture for LLM agents, built as
+zero-dependency TypeScript and published under Apache-2.0. On LongMemEval-500 it wins all nine
+head-to-head answer-quality comparisons against Letta, Mem0 and A-Mem (three competitors x three
+LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's binary-judge
+accuracy at 1/106th of the per-query token cost.
+
+- Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+
+License: Apache-2.0

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -27,9 +27,15 @@
   "keywords": [
     "zenbrain",
     "sqlite",
+    "better-sqlite3",
     "ai-memory",
+    "agent-memory",
+    "long-term-memory",
     "storage-adapter",
-    "zero-config"
+    "zero-config",
+    "embedded-database",
+    "llm-memory",
+    "ai-agents"
   ],
   "author": "ZenSation <open-source@zensation.ai>",
   "license": "Apache-2.0",

--- a/packages/algorithms/README.md
+++ b/packages/algorithms/README.md
@@ -246,3 +246,18 @@ This package is part of the [ZenBrain](https://github.com/zensation-ai/zenbrain)
 ## License
 
 Apache 2.0 — see [LICENSE](../../LICENSE).
+
+## About ZenBrain
+
+ZenBrain is a seven-layer, neuroscience-derived memory architecture for LLM agents, built as
+zero-dependency TypeScript and published under Apache-2.0. On LongMemEval-500 it wins all nine
+head-to-head answer-quality comparisons against Letta, Mem0 and A-Mem (three competitors x three
+LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's binary-judge
+accuracy at 1/106th of the per-query token cost.
+
+- Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+
+License: Apache-2.0

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,3 +75,18 @@ This package is part of the [ZenBrain](https://github.com/zensation-ai/zenbrain)
 ## License
 
 Apache 2.0 — see [LICENSE](../../LICENSE).
+
+## About ZenBrain
+
+ZenBrain is a seven-layer, neuroscience-derived memory architecture for LLM agents, built as
+zero-dependency TypeScript and published under Apache-2.0. On LongMemEval-500 it wins all nine
+head-to-head answer-quality comparisons against Letta, Mem0 and A-Mem (three competitors x three
+LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's binary-judge
+accuracy at 1/106th of the per-query token cost.
+
+- Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+
+License: Apache-2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,14 +68,19 @@
   },
   "keywords": [
     "ai-memory",
+    "agent-memory",
     "memory-layers",
     "working-memory",
     "episodic-memory",
+    "semantic-memory",
     "procedural-memory",
     "long-term-memory",
     "ai-agents",
+    "llm-memory",
     "neuroscience",
-    "pluggable-adapters"
+    "cognitive-architecture",
+    "pluggable-adapters",
+    "zenbrain"
   ],
   "author": "ZenSation <open-source@zensation.ai>",
   "license": "Apache-2.0",

--- a/scripts/verify-zero-dependencies.sh
+++ b/scripts/verify-zero-dependencies.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verifies the zero-dependency claim the README makes, against the packed artifacts
+# rather than against the source tree — a devDependency or a workspace link cannot
+# hide from this.
+#
+#   @zensation/algorithms  must resolve to exactly 1 package (itself)
+#   @zensation/core        must resolve to exactly 2 (itself + algorithms)
+#
+# Runs in CI on every push and pull request, so the claim cannot quietly stop being
+# true between releases. Run it yourself: bash scripts/verify-zero-dependencies.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "Packing the publishable artifacts…"
+ALG_TGZ="$(cd "$ROOT/packages/algorithms" && npm pack --silent --pack-destination "$WORK")"
+CORE_TGZ="$(cd "$ROOT/packages/core" && npm pack --silent --pack-destination "$WORK")"
+echo "  $ALG_TGZ"
+echo "  $CORE_TGZ"
+
+count_tree () {  # tarball expected_name -> number of packages in the resolved tree
+  local dir="$WORK/probe-$2"
+  mkdir -p "$dir"
+  (cd "$dir" && npm init -y >/dev/null 2>&1 \
+     && npm install --package-lock-only --ignore-scripts --silent "$1" >/dev/null 2>&1)
+  node -e "
+    const lock = require('$dir/package-lock.json');
+    const pkgs = Object.keys(lock.packages || {}).filter(k => k !== '');
+    console.log(pkgs.length);
+  "
+}
+
+fail=0
+
+echo
+echo "Resolving dependency trees from the packed tarballs…"
+alg=$(count_tree "$WORK/$ALG_TGZ" algorithms)
+core=$(count_tree "$WORK/$CORE_TGZ" core)
+
+printf '  %-26s %s package(s), expected 1  ' "@zensation/algorithms" "$alg"
+if [ "$alg" -eq 1 ]; then echo "OK"; else echo "FAIL"; fail=1; fi
+
+printf '  %-26s %s package(s), expected 2  ' "@zensation/core" "$core"
+if [ "$core" -eq 2 ]; then echo "OK"; else echo "FAIL"; fail=1; fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "Zero-dependency claim BROKEN. Either fix the dependency or change the claim in"
+  echo "README.md, the package descriptions and the elevator text — not just here."
+  exit 1
+fi
+
+echo "Zero-dependency claim holds: the core chain pulls nothing but our own code."


### PR DESCRIPTION
Follow-up to #61, on the npm side.

**Both adapter READMEs had zero links back to anything we own.** Rendered on npmjs.com they were dead ends — no repository, no paper, no playground, no sibling packages. All four package READMEs now carry the same About section, so any entry point leads to the others.

**Keywords.** npm indexes title, description, readme and keywords. `core` carried nine and was missing `agent-memory` — the category term `algorithms` already had. The adapters carried five each against fifteen for `algorithms`.

| package | before | after |
|---|--:|--:|
| `@zensation/core` | 9 | 14 |
| `@zensation/adapter-postgres` | 5 | 11 |
| `@zensation/adapter-sqlite` | 5 | 11 |

**`scripts/verify-zero-dependencies.sh` (new, wired into CI).** The README claims zero runtime dependencies. Until now nothing checked it. The script packs the publishable tarballs and resolves each in an empty project: `algorithms` must come to exactly one package, `core` to exactly two. It runs against the *packed artifact*, so a devDependency or a workspace link cannot hide from it, and it sits inside the required `test` check — a claim that is gated rather than asserted.

Local run:
```
  @zensation/algorithms      1 package(s), expected 1  OK
  @zensation/core            2 package(s), expected 2  OK
```

Keyword and README changes reach npmjs.com on the next publish; nothing here publishes by itself.