### PR TITLE
feat(mcp): MCP server so any client can use the seven layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: cd packages/adapters/postgres && npm run build
       - name: Build adapter-sqlite
         run: cd packages/adapters/sqlite && npm run build
+      - name: Build mcp
+        run: cd packages/mcp && npm run build
 
       # Type-check (after build so cross-package imports resolve)
       - name: Lint algorithms
@@ -39,6 +41,8 @@ jobs:
         run: cd packages/adapters/postgres && npx tsc --noEmit
       - name: Lint adapter-sqlite
         run: cd packages/adapters/sqlite && npx tsc --noEmit
+      - name: Lint mcp
+        run: cd packages/mcp && npx tsc --noEmit
 
       # Test all packages
       - name: Test algorithms
@@ -49,6 +53,14 @@ jobs:
         run: cd packages/adapters/postgres && npx vitest run --passWithNoTests
       - name: Test adapter-sqlite
         run: cd packages/adapters/sqlite && npx vitest run --passWithNoTests
+      - name: Test mcp
+        run: cd packages/mcp && npx vitest run
+
+      # Green unit tests do not prove the *binary* runs: a bad bin path, a broken
+      # shebang or a native module that fails to load all pass in-process and fail
+      # on a user's machine. Spawn the built entry point and talk MCP to it.
+      - name: Smoke-test the MCP server binary
+        run: node scripts/smoke-mcp.mjs
 
       # Smoke-test the self-contained example so it cannot silently rot
       - name: Smoke-test example (basic-chatbot)
@@ -82,6 +94,7 @@ jobs:
       - run: cd packages/core && npm run build
       - run: cd packages/adapters/postgres && npm run build
       - run: cd packages/adapters/sqlite && npm run build
+      - run: cd packages/mcp && npm run build
       # Auth is via OIDC trusted publishing configured on npmjs.com (no NPM_TOKEN);
       # provenance attestations are generated automatically.
       # Idempotent: only publish a version that is not already on the registry,
@@ -119,6 +132,19 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           if npm view "@zensation/adapter-sqlite@$VERSION" version >/dev/null 2>&1; then
             echo "@zensation/adapter-sqlite@$VERSION already on npm — skipping"
+          else
+            npm publish --access public
+          fi
+      # Deliberately LAST. Trusted Publishing is configured per package on npmjs.com,
+      # and this job stops at the first failure — the half-release of 05.08.2026 is
+      # exactly that lesson. Until @zensation/mcp has its own trusted publisher, this
+      # step can fail without taking the four established packages down with it.
+      - name: Publish mcp (skip if already published)
+        run: |
+          cd packages/mcp
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@zensation/mcp@$VERSION" version >/dev/null 2>&1; then
+            echo "@zensation/mcp@$VERSION already on npm — skipping"
           else
             npm publish --access public
           fi

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ const dueItems = await memory.getReviewQueue();
 | [`@zensation/core`](./packages/core) | Memory layers, coordinator, adapter interfaces | :white_check_mark: Published |
 | [`@zensation/adapter-postgres`](./packages/adapters/postgres) | PostgreSQL + pgvector storage adapter | :white_check_mark: Published |
 | [`@zensation/adapter-sqlite`](./packages/adapters/sqlite) | SQLite storage adapter (zero-config) | :white_check_mark: Published |
+| [`@zensation/mcp`](./packages/mcp) | MCP server — gives any MCP client (Claude Desktop, Claude Code, Cursor) the seven layers as four tools. Carries the protocol SDK, so the core stays dependency-free | :construction: Unreleased |
 
 ### Tree-Shakeable Imports
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,126 @@
+# @zensation/mcp
+
+**Status: 0.1.0, early release.** The tool surface is small on purpose and may still
+change before 1.0. The memory layers underneath it are the same ones the
+[ZenBrain paper](https://arxiv.org/abs/2604.23878) describes and the
+[benchmarks](https://github.com/zensation-ai/zenbrain/blob/main/docs/benchmarks.md) measure.
+
+An [MCP](https://modelcontextprotocol.io) server that gives any MCP client — Claude
+Desktop, Claude Code, Cursor, or your own — a memory that survives the conversation.
+
+Four tools, one local SQLite file, no account and no network call.
+
+| Tool | What it does |
+|---|---|
+| `zenbrain_store` | Write something into long-term memory. Routing is automatic: a general statement becomes a semantic fact, a narrated event an episode, a sequence of instructions a procedure. |
+| `zenbrain_recall` | Search every layer for what is relevant to a query. Results come back ranked, each tagged with the layer it came from. |
+| `zenbrain_consolidate` | One sleep-like maintenance pass: promote repeated episodes into facts, decay stale slots, prune what fell below the retention threshold. |
+| `zenbrain_health` | How full each layer is: slots in use, episodes, facts and how many are due for review, procedures, core blocks. |
+
+## Install
+
+Requires **Node.js 22 or newer**.
+
+```bash
+npm install -g @zensation/mcp
+```
+
+## Configure your client
+
+```json
+{
+  "mcpServers": {
+    "zenbrain": {
+      "command": "npx",
+      "args": ["-y", "@zensation/mcp"],
+      "env": {
+        "ZENBRAIN_DB": "~/.zenbrain/memory.db"
+      }
+    }
+  }
+}
+```
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ZENBRAIN_DB` | `./zenbrain.db` | Path to the SQLite file. `:memory:` gives a store that is discarded when the process exits. |
+| `ZENBRAIN_CONTEXTS` | `personal,work,learning,creative` | Comma-separated context domains for cross-context memory. |
+
+The server speaks MCP over stdio. Stdout carries protocol traffic only; diagnostics go
+to stderr.
+
+## The seven layers
+
+Storing is not filing. Which layer a memory lands in decides how it decays, how it is
+retrieved, and whether it survives consolidation.
+
+| | Layer | Holds |
+|--:|---|---|
+| 7 | Cross-Context Memory | Shared knowledge across domains |
+| 6 | Core Memory | Pinned facts |
+| 5 | Procedural Memory | "How to do X" — skills and workflows |
+| 4 | Long-Term Semantic | Facts, with FSRS scheduling |
+| 3 | Episodic Memory | Concrete experiences and events |
+| 2 | Short-Term / Session | Current conversation context |
+| 1 | Working Memory | Active task focus, 7±2 items |
+
+Each layer has its own retention, consolidation and retrieval rules. Review scheduling
+follows a forgetting curve rather than a fixed timer, and emotionally weighted content
+consolidates more strongly; both are implemented in
+[`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) and can be
+read line by line.
+
+This server configures **no LLM provider**, so nothing in it calls a model: routing on
+store is a content heuristic, and consolidation runs without generated summaries.
+
+## What this release does not do
+
+Worth knowing before you wire it in:
+
+- **No embedding provider is configured by default.** Semantic search degrades to the
+  non-vector path. Recall still works; it is less sharp than the benchmarked
+  configuration. Pass an `EmbeddingProvider` through the library if you need that today.
+- **SQLite similarity search is a full scan.** Fine for one person's memory; use
+  [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres)
+  for larger volumes.
+- **Consolidation is a tool call, not a schedule.** Nothing runs it for you.
+- **The store is a plain file.** It is not encrypted. Put it somewhere you would put a
+  notebook.
+
+## Using it as a library
+
+The server factory is exported, so you can mount ZenBrain's tools on a server of your own
+or drive them in tests:
+
+```typescript
+import { createZenBrainServer } from '@zensation/mcp/server';
+import { MemoryCoordinator } from '@zensation/core';
+import { SqliteAdapter } from '@zensation/adapter-sqlite';
+
+const coordinator = new MemoryCoordinator({
+  storage: new SqliteAdapter({ filename: './memory.db' }),
+});
+
+const server = createZenBrainServer(coordinator);
+// connect it to any transport you like — the caller owns the coordinator's lifecycle
+```
+
+## Zero-dependency, and where that stops
+
+`@zensation/algorithms` and `@zensation/core` pull nothing but each other. That claim is
+[checked in CI on every push](https://github.com/zensation-ai/zenbrain/blob/main/scripts/verify-zero-dependencies.sh)
+against the packed tarballs, not against the source tree.
+
+**This package is deliberately outside that boundary.** An MCP server needs the protocol
+SDK, so it carries one. Keeping it in its own package is what lets the core stay clean:
+installing `@zensation/core` never pulls the MCP SDK, and installing this never weakens
+the claim the core makes.
+
+## Links
+
+- Repository: <https://github.com/zensation-ai/zenbrain>
+- Paper: <https://arxiv.org/abs/2604.23878>
+- Playground: <https://zensation.ai/en/playground>
+- Registry entry: `ai.zensation/zenbrain`
+
+Apache-2.0.

--- a/packages/mcp/__tests__/server.test.ts
+++ b/packages/mcp/__tests__/server.test.ts
@@ -1,0 +1,199 @@
+/**
+ * These tests drive the real MCP protocol.
+ *
+ * A real Client talks to the real server over a linked in-memory transport and
+ * calls the tools the way Claude Desktop or Cursor would. A compiling server
+ * that no client can call would pass a unit test and fail in the wild — this
+ * catches that.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  MemoryCoordinator,
+  InMemoryStorage,
+  FakeEmbeddingProvider,
+  InMemoryCache,
+} from '@zensation/core';
+import { createZenBrainServer } from '../src/server.js';
+
+let client: Client;
+let coordinator: MemoryCoordinator;
+
+async function connect() {
+  coordinator = new MemoryCoordinator({
+    storage: new InMemoryStorage(),
+    embedding: new FakeEmbeddingProvider(),
+    cache: new InMemoryCache(),
+  });
+  const server = createZenBrainServer(coordinator, { version: '0.1.0-test' });
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientSide), server.connect(serverSide)]);
+}
+
+beforeEach(connect);
+afterEach(async () => {
+  await client.close();
+  await coordinator.close();
+});
+
+describe('the tool surface', () => {
+  it('advertises exactly the four ZenBrain tools', async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'zenbrain_consolidate',
+      'zenbrain_health',
+      'zenbrain_recall',
+      'zenbrain_store',
+    ]);
+  });
+
+  it('gives every tool a description a model can act on', async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.description, `${tool.name} has no description`).toBeTruthy();
+      expect(tool.description!.length).toBeGreaterThan(60);
+      expect(tool.inputSchema).toBeDefined();
+    }
+  });
+});
+
+describe('zenbrain_store', () => {
+  it('stores content and returns an id', async () => {
+    const res = await client.callTool({
+      name: 'zenbrain_store',
+      arguments: { content: 'The user prefers dark mode in every editor.' },
+    });
+    expect(res.isError).toBeFalsy();
+    const { id } = res.structuredContent as { id: string };
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the full option set without dropping a field', async () => {
+    const res = await client.callTool({
+      name: 'zenbrain_store',
+      arguments: {
+        content: 'Deploy by tagging a release.',
+        type: 'procedure',
+        context: 'work',
+        confidence: 0.8,
+        emotionalWeight: 0.2,
+        source: 'user',
+        steps: ['bump the version', 'tag it', 'push the tag'],
+        tools: ['git', 'npm'],
+        outcome: 'a published release',
+      },
+    });
+    expect(res.isError).toBeFalsy();
+    expect((res.structuredContent as { id: string }).id).toBeTruthy();
+  });
+
+  it('rejects empty content instead of storing a blank memory', async () => {
+    const res = await client.callTool({
+      name: 'zenbrain_store',
+      arguments: { content: '' },
+    });
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe('zenbrain_recall', () => {
+  // NOTE ON THE FIXTURE: `InMemoryStorage` is deliberately not a SQL engine — its
+  // own docstring says so, and its INSERT keeps parameters as `col_0`, `col_1`, …
+  // with no `content` column. So recall over this double yields rows that carry a
+  // layer and a score but no content. That makes it the ideal fixture for the
+  // hardening below, and the wrong fixture for a content round-trip. The
+  // round-trip is covered in `sqlite-integration.test.ts` against the real
+  // adapter — the same path a user gets.
+
+  it('returns an empty result set rather than failing when nothing matches', async () => {
+    const res = await client.callTool({
+      name: 'zenbrain_recall',
+      arguments: { query: 'something nobody ever stored' },
+    });
+    expect(res.isError).toBeFalsy();
+    expect((res.structuredContent as { count: number }).count).toBe(0);
+  });
+
+  it('survives rows with no readable content instead of erroring the whole call', async () => {
+    await client.callTool({
+      name: 'zenbrain_store',
+      arguments: { content: 'The capital of France is Paris.', type: 'fact' },
+    });
+
+    const res = await client.callTool({
+      name: 'zenbrain_recall',
+      arguments: { query: 'capital of France' },
+    });
+
+    // The whole point: a malformed row must not become a protocol error.
+    expect(res.isError).toBeFalsy();
+    const out = res.structuredContent as {
+      count: number;
+      results: unknown[];
+      skipped: number;
+    };
+    expect(out.results.length).toBe(out.count);
+    // Something was retrieved — it just was not renderable through this double.
+    expect(out.count + out.skipped).toBeGreaterThan(0);
+    expect(out.skipped).toBeGreaterThan(0);
+  });
+
+  it('accepts the layer filter without erroring', async () => {
+    const res = await client.callTool({
+      name: 'zenbrain_recall',
+      arguments: { query: 'Redis port', layers: ['semantic'], limit: 5 },
+    });
+    expect(res.isError).toBeFalsy();
+    const out = res.structuredContent as { results: { layer: string }[] };
+    for (const r of out.results) expect(r.layer).toBe('semantic');
+  });
+
+  it('rejects a layer name the coordinator does not know', async () => {
+    const res = await client.callTool({
+      name: 'zenbrain_recall',
+      arguments: { query: 'anything', layers: ['hippocampus'] },
+    });
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe('zenbrain_consolidate and zenbrain_health', () => {
+  it('consolidates and reports three counters', async () => {
+    const res = await client.callTool({ name: 'zenbrain_consolidate', arguments: {} });
+    expect(res.isError).toBeFalsy();
+    const out = res.structuredContent as Record<string, number>;
+    for (const key of ['promoted', 'decayed', 'pruned']) {
+      expect(typeof out[key], `${key} missing`).toBe('number');
+    }
+  });
+
+  it('reports every layer in the health check', async () => {
+    const res = await client.callTool({ name: 'zenbrain_health', arguments: {} });
+    expect(res.isError).toBeFalsy();
+    const text = (res.content as { type: string; text: string }[])[0].text;
+    const health = JSON.parse(text) as Record<string, unknown>;
+    for (const layer of ['working', 'shortTerm', 'episodic', 'semantic', 'procedural', 'core']) {
+      expect(health[layer], `${layer} missing from health`).toBeDefined();
+    }
+  });
+});
+
+describe('every tool answers in a shape any MCP client can render', () => {
+  it('returns a text block alongside the structured payload', async () => {
+    for (const [name, args] of [
+      ['zenbrain_store', { content: 'a memory' }],
+      ['zenbrain_recall', { query: 'a memory' }],
+      ['zenbrain_consolidate', {}],
+      ['zenbrain_health', {}],
+    ] as const) {
+      const res = await client.callTool({ name, arguments: args });
+      const content = res.content as { type: string; text?: string }[];
+      expect(content.length, `${name} returned no content`).toBeGreaterThan(0);
+      expect(content[0].type).toBe('text');
+      expect(() => JSON.parse(content[0].text!)).not.toThrow();
+    }
+  });
+});

--- a/packages/mcp/__tests__/sqlite-integration.test.ts
+++ b/packages/mcp/__tests__/sqlite-integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The MCP surface over the storage a user actually gets.
+ *
+ * `server.test.ts` proves the protocol contract against an in-memory double that
+ * cannot round-trip content. This file proves the part that only a real adapter
+ * can: that `zenbrain_recall` hands the client back the text that was stored.
+ *
+ * Needs Node >= 22, because `better-sqlite3` 13 does. CI runs 22, 24 and 26. If
+ * the native module cannot load, the suite says so loudly rather than reporting
+ * a quiet pass — a check that never runs is worse than one that fails.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { MemoryCoordinator, FakeEmbeddingProvider, InMemoryCache } from '@zensation/core';
+import { createZenBrainServer } from '../src/server.js';
+
+// The version gate has to come BEFORE the import. `better-sqlite3` 13 is a native
+// module: on an unsupported Node it does not throw, it takes the worker down with
+// it — so a try/catch around the import is not a guard, and the whole file would
+// die together with the suites next to it.
+const NODE_MAJOR = Number(process.versions.node.split('.')[0]);
+const SUPPORTED = NODE_MAJOR >= 22;
+
+let sqlite: typeof import('@zensation/adapter-sqlite') | undefined;
+let loadError: unknown;
+
+if (SUPPORTED) {
+  try {
+    sqlite = await import('@zensation/adapter-sqlite');
+  } catch (err) {
+    loadError = err;
+  }
+} else {
+  process.stderr.write(
+    `\n[sqlite-integration] SKIPPED — Node ${process.version} is below the ` +
+      `engines floor of >= 22 that better-sqlite3 13 requires. ` +
+      `This suite is expected to RUN in CI (22, 24, 26); a green local run here ` +
+      `proves nothing about it.\n\n`,
+  );
+}
+
+const open: typeof describe.skip = sqlite ? describe : describe.skip;
+
+let coordinator: MemoryCoordinator | undefined;
+let client: Client | undefined;
+
+async function connect() {
+  coordinator = new MemoryCoordinator({
+    storage: new sqlite!.SqliteAdapter({ filename: ':memory:' }),
+    embedding: new FakeEmbeddingProvider(),
+    cache: new InMemoryCache(),
+  });
+  const server = createZenBrainServer(coordinator);
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: 'sqlite-test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientSide), server.connect(serverSide)]);
+  return client;
+}
+
+afterEach(async () => {
+  await client?.close();
+  await coordinator?.close();
+  client = undefined;
+  coordinator = undefined;
+});
+
+open('the MCP surface over a real SQLite store', () => {
+  it('loaded the adapter at all', () => {
+    expect(loadError, String(loadError)).toBeUndefined();
+  });
+
+  it('recalls the text that was stored', async () => {
+    const c = await connect();
+    await c.callTool({
+      name: 'zenbrain_store',
+      arguments: { content: 'Anna moved to Hamburg in March.', type: 'fact' },
+    });
+
+    const res = await c.callTool({
+      name: 'zenbrain_recall',
+      arguments: { query: 'Anna Hamburg', limit: 5 },
+    });
+    expect(res.isError).toBeFalsy();
+
+    const out = res.structuredContent as {
+      count: number;
+      skipped: number;
+      results: { content: string; layer: string; score: number }[];
+    };
+    expect(out.count).toBeGreaterThan(0);
+    expect(out.skipped).toBe(0);
+    expect(out.results.some((r) => r.content.includes('Hamburg'))).toBe(true);
+    for (const r of out.results) {
+      expect(typeof r.content).toBe('string');
+      expect(typeof r.layer).toBe('string');
+      expect(typeof r.score).toBe('number');
+    }
+  });
+
+  it('honours the layer filter on real data', async () => {
+    const c = await connect();
+    await c.callTool({
+      name: 'zenbrain_store',
+      arguments: { content: 'Redis listens on port 6379.', type: 'fact' },
+    });
+
+    const res = await c.callTool({
+      name: 'zenbrain_recall',
+      arguments: { query: 'Redis port', layers: ['semantic'], limit: 5 },
+    });
+    expect(res.isError).toBeFalsy();
+    const out = res.structuredContent as { results: { layer: string }[] };
+    expect(out.results.length).toBeGreaterThan(0);
+    for (const r of out.results) expect(r.layer).toBe('semantic');
+  });
+
+  it('reports the stored fact in the health check', async () => {
+    const c = await connect();
+    await c.callTool({
+      name: 'zenbrain_store',
+      arguments: { content: 'The build runs on Node 22.', type: 'fact' },
+    });
+
+    const res = await c.callTool({ name: 'zenbrain_health', arguments: {} });
+    expect(res.isError).toBeFalsy();
+    const health = JSON.parse((res.content as { text: string }[])[0].text) as {
+      semantic: { count: number };
+    };
+    expect(health.semantic.count).toBeGreaterThan(0);
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@zensation/mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol server for ZenBrain — gives any MCP client a 7-layer memory: store, recall, consolidate, inspect.",
+  "mcpName": "ai.zensation/zenbrain",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "zenbrain-mcp": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "server.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "zenbrain",
+    "agent-memory",
+    "ai-memory",
+    "memory-layer",
+    "long-term-memory",
+    "episodic-memory",
+    "stateful-agents",
+    "llm-memory"
+  ],
+  "author": "ZenSation <open-source@zensation.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zensation-ai/zenbrain.git",
+    "directory": "packages/mcp"
+  },
+  "homepage": "https://github.com/zensation-ai/zenbrain/tree/main/packages/mcp#readme",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@zensation/adapter-sqlite": "^0.2.0",
+    "@zensation/core": "^0.3.0"
+  },
+  "devDependencies": {
+    "@zensation/adapter-sqlite": "^0.2.0",
+    "@zensation/core": "^0.3.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "ai.zensation/zenbrain",
+  "title": "ZenBrain Memory",
+  "description": "Seven-layer agent memory: episodic, semantic, procedural and core. Local SQLite, no account.",
+  "websiteUrl": "https://zensation.ai/en/open-source",
+  "repository": {
+    "url": "https://github.com/zensation-ai/zenbrain",
+    "source": "github",
+    "subfolder": "packages/mcp"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@zensation/mcp",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ZENBRAIN_DB",
+          "description": "Path to the SQLite file that holds the memory. Use ':memory:' for a store that is discarded when the process exits.",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "./zenbrain.db"
+        },
+        {
+          "name": "ZENBRAIN_CONTEXTS",
+          "description": "Comma-separated context domains for cross-context memory.",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "personal,work,learning,creative"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * `zenbrain-mcp` — the executable entry point.
+ *
+ * Wires a file-backed SQLite store to a MemoryCoordinator and speaks MCP over
+ * stdio. Everything configurable is an environment variable, because that is the
+ * only thing an MCP client config can set.
+ *
+ *   ZENBRAIN_DB        Path to the SQLite file.   Default: ./zenbrain.db
+ *                      Use ':memory:' for a store that dies with the process.
+ *   ZENBRAIN_CONTEXTS  Comma-separated context domains.
+ *                      Default: personal,work,learning,creative
+ *
+ * Nothing is written to stdout except protocol traffic — stdout *is* the
+ * transport. Diagnostics go to stderr.
+ */
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { MemoryCoordinator } from '@zensation/core';
+import { SqliteAdapter } from '@zensation/adapter-sqlite';
+import { createZenBrainServer } from './server.js';
+
+export { createZenBrainServer } from './server.js';
+export type { ZenBrainServerOptions } from './server.js';
+
+async function main(): Promise<void> {
+  const filename = process.env.ZENBRAIN_DB ?? './zenbrain.db';
+  const contexts = process.env.ZENBRAIN_CONTEXTS?.split(',')
+    .map((c) => c.trim())
+    .filter(Boolean);
+
+  const storage = new SqliteAdapter({ filename });
+  const coordinator = new MemoryCoordinator({
+    storage,
+    ...(contexts && contexts.length > 0 ? { contexts } : {}),
+  });
+
+  const server = createZenBrainServer(coordinator);
+
+  const shutdown = async (): Promise<void> => {
+    try {
+      await server.close();
+    } finally {
+      await coordinator.close();
+    }
+  };
+  process.on('SIGINT', () => void shutdown().finally(() => process.exit(0)));
+  process.on('SIGTERM', () => void shutdown().finally(() => process.exit(0)));
+
+  await server.connect(new StdioServerTransport());
+  process.stderr.write(`zenbrain-mcp ready — store: ${filename}\n`);
+}
+
+// Only run when executed, not when imported. `process.argv[1]` is the script
+// path the runtime was handed; comparing against import.meta.url is the
+// ESM-safe form of the CommonJS `require.main === module` check.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  main().catch((err: unknown) => {
+    process.stderr.write(`zenbrain-mcp failed to start: ${String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,237 @@
+/**
+ * The MCP surface of ZenBrain.
+ *
+ * This module builds the server around an already-constructed MemoryCoordinator
+ * rather than constructing one itself. That is what makes it testable: the tests
+ * drive the real protocol over an in-memory transport against an in-memory store,
+ * and never touch a file or a database. `index.ts` does the wiring for real use.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type {
+  MemoryCoordinator,
+  RecallOptions,
+  RecallResult,
+  StoreOptions,
+} from '@zensation/core';
+
+/** Layer names the coordinator accepts in `RecallOptions.layers`. */
+const LAYERS = ['working', 'episodic', 'semantic', 'procedural', 'core'] as const;
+
+/** Routing hints the coordinator accepts in `StoreOptions.type`. */
+const STORE_TYPES = ['auto', 'fact', 'episode', 'procedure', 'core'] as const;
+
+export interface ZenBrainServerOptions {
+  /** Reported to the client during initialization. Defaults to the package name. */
+  name?: string;
+  /** Reported to the client during initialization. */
+  version?: string;
+}
+
+/** Renders a value as the text block every MCP client can display. */
+function text(value: unknown) {
+  return [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }];
+}
+
+/**
+ * Builds the ZenBrain MCP server.
+ *
+ * @param coordinator A live MemoryCoordinator. The caller owns its lifecycle —
+ *   this function never closes it.
+ */
+export function createZenBrainServer(
+  coordinator: MemoryCoordinator,
+  options: ZenBrainServerOptions = {},
+): McpServer {
+  const server = new McpServer({
+    name: options.name ?? '@zensation/mcp',
+    version: options.version ?? '0.1.0',
+  });
+
+  // ── store ────────────────────────────────────────────────────────────────
+  server.registerTool(
+    'zenbrain_store',
+    {
+      title: 'Store a memory',
+      description:
+        'Write something into long-term memory so it survives this conversation. ' +
+        'Routing is automatic by default: a general statement becomes a semantic fact, ' +
+        'a narrated event becomes an episode, a sequence of instructions becomes a procedure. ' +
+        'Set `type` only when you want to override that. Returns the id of the stored memory.',
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+      inputSchema: {
+        content: z.string().min(1).describe('The memory to store, in plain language.'),
+        type: z
+          .enum(STORE_TYPES)
+          .optional()
+          .describe("Routing hint. 'auto' (default) decides from the content."),
+        context: z
+          .string()
+          .optional()
+          .describe("Context domain, e.g. 'work', 'personal', 'learning'."),
+        confidence: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe('How certain this is (0–1). Above 0.9 routes to core memory.'),
+        emotionalWeight: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe('Emotional significance (0–1). Detected from the content when omitted.'),
+        source: z
+          .string()
+          .optional()
+          .describe("Where this came from, e.g. 'user', 'ai', 'import'."),
+        steps: z
+          .array(z.string())
+          .optional()
+          .describe("Ordered steps. Required when type is 'procedure'."),
+        tools: z.array(z.string()).optional().describe('Tools a procedure uses.'),
+        outcome: z.string().optional().describe('What the procedure achieves.'),
+      },
+      outputSchema: {
+        id: z.string().describe('Identifier of the stored memory.'),
+      },
+    },
+    async ({ content, ...rest }) => {
+      const opts: StoreOptions = {};
+      if (rest.type !== undefined) opts.type = rest.type;
+      if (rest.context !== undefined) opts.context = rest.context;
+      if (rest.confidence !== undefined) opts.confidence = rest.confidence;
+      if (rest.emotionalWeight !== undefined) opts.emotionalWeight = rest.emotionalWeight;
+      if (rest.source !== undefined) opts.source = rest.source;
+      if (rest.steps !== undefined) opts.steps = rest.steps;
+      if (rest.tools !== undefined) opts.tools = rest.tools;
+      if (rest.outcome !== undefined) opts.outcome = rest.outcome;
+
+      const id = await coordinator.store(content, opts);
+      return { content: text({ id }), structuredContent: { id } };
+    },
+  );
+
+  // ── recall ───────────────────────────────────────────────────────────────
+  server.registerTool(
+    'zenbrain_recall',
+    {
+      title: 'Recall memories',
+      description:
+        'Search long-term memory for anything relevant to a query. Searches every layer ' +
+        'by default and returns results ranked by relevance, each tagged with the layer it ' +
+        'came from. Use this before answering when the user refers to something from an ' +
+        'earlier session.',
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      inputSchema: {
+        query: z.string().min(1).describe('What to look for, in plain language.'),
+        layers: z
+          .array(z.enum(LAYERS))
+          .optional()
+          .describe('Restrict the search to these layers. Defaults to all but working.'),
+        limit: z.number().int().min(1).max(100).optional().describe('Maximum results (default 10).'),
+        minConfidence: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe('Drop results below this confidence.'),
+        includeContext: z
+          .boolean()
+          .optional()
+          .describe('Boost results matching the current context.'),
+        taskType: z
+          .string()
+          .optional()
+          .describe("Current task, e.g. 'coding', 'writing' — used for context matching."),
+      },
+      outputSchema: {
+        count: z.number().describe('How many memories were returned.'),
+        results: z
+          .array(
+            z.object({
+              content: z.string(),
+              layer: z.string(),
+              score: z.number(),
+              confidence: z.number().optional(),
+              emotionalWeight: z.number().optional(),
+            }),
+          )
+          .describe('Matching memories, most relevant first.'),
+        skipped: z
+          .number()
+          .describe('Rows that carried no readable content and were left out of `results`.'),
+      },
+    },
+    async ({ query, ...rest }) => {
+      const opts: RecallOptions = {};
+      if (rest.layers !== undefined) opts.layers = rest.layers as RecallOptions['layers'];
+      if (rest.limit !== undefined) opts.limit = rest.limit;
+      if (rest.minConfidence !== undefined) opts.minConfidence = rest.minConfidence;
+      if (rest.includeContext !== undefined) opts.includeContext = rest.includeContext;
+      if (rest.taskType !== undefined) opts.taskType = rest.taskType;
+
+      const found: RecallResult[] = await coordinator.recall(query, opts);
+
+      // `RecallResult.content` is typed as a required string, but it is assembled
+      // from whatever the storage adapter returns. A row that lost its content
+      // column would otherwise fail output validation and turn a good recall into
+      // a protocol error for the client. Leave those rows out and say how many.
+      const usable = found.filter((r) => typeof r.content === 'string' && r.content.length > 0);
+      const results = usable.map((r) => ({
+        content: r.content,
+        layer: typeof r.layer === 'string' ? r.layer : 'unknown',
+        score: typeof r.score === 'number' ? r.score : 0,
+        ...(typeof r.confidence === 'number' ? { confidence: r.confidence } : {}),
+        ...(typeof r.emotionalWeight === 'number' ? { emotionalWeight: r.emotionalWeight } : {}),
+      }));
+
+      const payload = { count: results.length, results, skipped: found.length - usable.length };
+      return { content: text(payload), structuredContent: payload };
+    },
+  );
+
+  // ── consolidate ──────────────────────────────────────────────────────────
+  server.registerTool(
+    'zenbrain_consolidate',
+    {
+      title: 'Consolidate memory',
+      description:
+        'Run one consolidation pass: promote repeated episodes into semantic facts, decay ' +
+        'stale working-memory slots, prune what has fallen below the retention threshold. ' +
+        'This is the sleep-like maintenance step — safe to run periodically, not per turn.',
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+      inputSchema: {},
+      outputSchema: {
+        promoted: z.number().describe('Episodes promoted to semantic facts.'),
+        decayed: z.number().describe('Working-memory slots decayed.'),
+        pruned: z.number().describe('Items pruned below the retention threshold.'),
+      },
+    },
+    async () => {
+      const r = await coordinator.consolidate();
+      const payload = { promoted: r.promoted, decayed: r.decayed, pruned: r.pruned };
+      return { content: text(payload), structuredContent: payload };
+    },
+  );
+
+  // ── health ───────────────────────────────────────────────────────────────
+  server.registerTool(
+    'zenbrain_health',
+    {
+      title: 'Inspect memory state',
+      description:
+        'Report how full each of the seven layers is: working-memory slots in use, ' +
+        'interactions held, episodes, facts and how many are due for review, procedures, ' +
+        'core blocks. Use it to check what the agent actually remembers.',
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      inputSchema: {},
+    },
+    async () => {
+      const health = await coordinator.getHealth();
+      return { content: text(health) };
+    },
+  );
+
+  return server;
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+});

--- a/scripts/smoke-mcp.mjs
+++ b/scripts/smoke-mcp.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Runtime smoke test for the published MCP server.
+ *
+ * The unit suite drives `createZenBrainServer` in-process. That proves the tools
+ * are correct; it does not prove the *binary* works — a broken bin path, a bad
+ * shebang, an ESM/CJS mismatch or a native module that fails to load would all
+ * pass the unit suite and fail on a user's machine.
+ *
+ * So this spawns `packages/mcp/dist/index.js` as a real child process, talks to
+ * it over real stdio, and round-trips a memory through it.
+ *
+ *   node scripts/smoke-mcp.mjs
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const entry = join(root, 'packages/mcp/dist/index.js');
+
+function fail(msg) {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+if (!existsSync(entry)) fail(`built entry point missing: ${entry} — run the build first`);
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [entry],
+  // ':memory:' keeps the smoke test from leaving a database behind in CI.
+  env: { ...process.env, ZENBRAIN_DB: ':memory:' },
+  stderr: 'inherit',
+});
+
+const client = new Client({ name: 'zenbrain-smoke', version: '1.0.0' });
+await client.connect(transport);
+console.log('✓ the binary started and completed the MCP handshake');
+
+const { tools } = await client.listTools();
+const names = tools.map((t) => t.name).sort();
+const expected = ['zenbrain_consolidate', 'zenbrain_health', 'zenbrain_recall', 'zenbrain_store'];
+if (JSON.stringify(names) !== JSON.stringify(expected)) {
+  fail(`unexpected tool list: ${names.join(', ')}`);
+}
+console.log(`✓ advertises all four tools: ${names.join(', ')}`);
+
+const MEMORY = 'The smoke test stored this sentence in Hamburg.';
+
+const stored = await client.callTool({
+  name: 'zenbrain_store',
+  arguments: { content: MEMORY, type: 'fact' },
+});
+if (stored.isError) fail(`store failed: ${JSON.stringify(stored.content)}`);
+console.log(`✓ stored a memory, id ${stored.structuredContent.id}`);
+
+const recalled = await client.callTool({
+  name: 'zenbrain_recall',
+  arguments: { query: 'smoke test Hamburg', limit: 5 },
+});
+if (recalled.isError) fail(`recall failed: ${JSON.stringify(recalled.content)}`);
+
+const out = recalled.structuredContent;
+if (out.skipped > 0) fail(`recall dropped ${out.skipped} row(s) with unreadable content`);
+if (!out.results.some((r) => r.content.includes('Hamburg'))) {
+  fail(`recall did not return the stored sentence. Got: ${JSON.stringify(out)}`);
+}
+console.log(`✓ recalled it back through a real stdio round trip (${out.count} result(s))`);
+
+const health = await client.callTool({ name: 'zenbrain_health', arguments: {} });
+if (health.isError) fail('health failed');
+const layers = JSON.parse(health.content[0].text);
+for (const l of ['working', 'shortTerm', 'episodic', 'semantic', 'procedural', 'core']) {
+  if (layers[l] === undefined) fail(`health is missing the ${l} layer`);
+}
+console.log('✓ health reports every layer');
+
+await client.close();
+console.log('\nMCP server smoke test passed.');


### PR DESCRIPTION
Adds `@zensation/mcp` — four tools (`store`, `recall`, `consolidate`, `health`) over stdio, backed by a local SQLite file. No account, no network call.

### Why now

Measured on 28.08.2026: `@modelcontextprotocol/sdk` sits at **209.3 million downloads/month** on npm — larger than the Vercel AI SDK (90.0M). In Hacker News comments this year, `mcp` is mentioned 6,605 times against 44 for `mem0`. Mem0 ships `mem0-mcp` (658★) and Zep ships `zep-mcp-server`; ZenBrain had no MCP surface at all.

The official registry at `registry.modelcontextprotocol.io` is public and self-service, and its ranking does not depend on stars.

### Why a separate package

An MCP server needs the protocol SDK. `@zensation/core` must not. Keeping the SDK out here is what lets `scripts/verify-zero-dependencies.sh` keep passing unchanged — installing `@zensation/core` still resolves to exactly two packages.

### How this is verified

| Layer | What it actually proves |
|---|---|
| 12 protocol tests | A real MCP `Client` over a linked in-memory transport calls the tools the way Claude Desktop would — not the handler functions directly |
| 4 integration tests | The same calls against the **real** SQLite adapter, so content round-trips through real storage |
| `scripts/smoke-mcp.mjs` | Spawns the **built binary** as a child process and round-trips a memory through real stdio |

The integration suite is gated on Node >= 22 **before** the import: `better-sqlite3` does not throw on an unsupported runtime, it takes the worker down with it, so a `try/catch` around the import is not a guard. Below 22 the suite prints why it skipped instead of reporting a quiet pass.

### Two things the tests changed

- `zenbrain_recall` now tolerates rows whose `content` did not survive the storage adapter: it leaves them out and reports `skipped`, instead of failing the whole call with an output-validation error. Found by a test, not anticipated.
- `server.json` is validated against the official draft-07 registry schema. That caught a `description` over the 100-character cap.

### Before this can be published

- [ ] **Trusted Publisher for `@zensation/mcp`** on npmjs.com (`zensation-ai/zenbrain`, `ci.yml`). Configured per package — the publish step is deliberately **last** in the job so a missing publisher here cannot take the four established packages down with it, the way the half-release on 05.08. did.
- [ ] **DNS TXT record on `zensation.ai`** to claim the `ai.zensation/*` registry namespace. `package.json` already carries `mcpName: ai.zensation/zenbrain`, which is how npm ownership is proven to the registry.

Registry entry is prepared but **not** submitted.