### PR TITLE
feat(ai-sdk): ZenBrain as Vercel AI SDK middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         run: cd packages/adapters/sqlite && npm run build
       - name: Build mcp
         run: cd packages/mcp && npm run build
+      - name: Build ai-sdk
+        run: cd packages/ai-sdk && npm run build
 
       # Type-check (after build so cross-package imports resolve)
       - name: Lint algorithms
@@ -43,6 +45,8 @@ jobs:
         run: cd packages/adapters/sqlite && npx tsc --noEmit
       - name: Lint mcp
         run: cd packages/mcp && npx tsc --noEmit
+      - name: Lint ai-sdk
+        run: cd packages/ai-sdk && npx tsc --noEmit
 
       # Test all packages
       - name: Test algorithms
@@ -55,6 +59,8 @@ jobs:
         run: cd packages/adapters/sqlite && npx vitest run --passWithNoTests
       - name: Test mcp
         run: cd packages/mcp && npx vitest run
+      - name: Test ai-sdk
+        run: cd packages/ai-sdk && npx vitest run
 
       # Green unit tests do not prove the *binary* runs: a bad bin path, a broken
       # shebang or a native module that fails to load all pass in-process and fail
@@ -95,6 +101,7 @@ jobs:
       - run: cd packages/adapters/postgres && npm run build
       - run: cd packages/adapters/sqlite && npm run build
       - run: cd packages/mcp && npm run build
+      - run: cd packages/ai-sdk && npm run build
       # Auth is via OIDC trusted publishing configured on npmjs.com (no NPM_TOKEN);
       # provenance attestations are generated automatically.
       # Idempotent: only publish a version that is not already on the registry,
@@ -145,6 +152,18 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           if npm view "@zensation/mcp@$VERSION" version >/dev/null 2>&1; then
             echo "@zensation/mcp@$VERSION already on npm — skipping"
+          else
+            npm publish --access public
+          fi
+      # Same reasoning as the mcp step above: trusted publishing is per package and
+      # this job stops at the first failure, so a package without a publisher yet must
+      # not sit in front of the established ones.
+      - name: Publish ai-sdk (skip if already published)
+        run: |
+          cd packages/ai-sdk
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@zensation/ai-sdk@$VERSION" version >/dev/null 2>&1; then
+            echo "@zensation/ai-sdk@$VERSION already on npm — skipping"
           else
             npm publish --access public
           fi

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ const dueItems = await memory.getReviewQueue();
 | [`@zensation/adapter-postgres`](./packages/adapters/postgres) | PostgreSQL + pgvector storage adapter | :white_check_mark: Published |
 | [`@zensation/adapter-sqlite`](./packages/adapters/sqlite) | SQLite storage adapter (zero-config) | :white_check_mark: Published |
 | [`@zensation/mcp`](./packages/mcp) | MCP server — gives any MCP client (Claude Desktop, Claude Code, Cursor) the seven layers as four tools. Carries the protocol SDK, so the core stays dependency-free | :construction: Unreleased |
+| [`@zensation/ai-sdk`](./packages/ai-sdk) | Vercel AI SDK middleware — recall before the model call, store after it. Works with any provider, **zero runtime dependencies** | :construction: Unreleased |
 
 ### Tree-Shakeable Imports
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,57 @@
         "typescript": "^5.7.0"
       }
     },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.67",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.67.tgz",
+      "integrity": "sha512-LtyxLkg7dZ2iz8Ouh1806BJbA+q+FKc/mXUCl4v/wdNNIGtbfk80dNtlhqjhqOZa4dnfc3caVafRL7ocxzoegA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.8",
+        "@ai-sdk/provider-utils": "5.0.32",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.8.tgz",
+      "integrity": "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.32",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.32.tgz",
+      "integrity": "sha512-MZUhlINn6FzKIWuX3T36h+yM9d7bG+yatH+kC99ZCe0DHxXfP73KwaoLiLcZDPQDamFyO3umPPBLJieZJyG4DQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
@@ -544,6 +595,13 @@
         "darwin"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@turbo/darwin-64": {
       "version": "2.10.11",
       "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.11.tgz",
@@ -683,6 +741,16 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
@@ -798,12 +866,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@zensation/adapter-postgres": {
       "resolved": "packages/adapters/postgres",
       "link": true
     },
     "node_modules/@zensation/adapter-sqlite": {
       "resolved": "packages/adapters/sqlite",
+      "link": true
+    },
+    "node_modules/@zensation/ai-sdk": {
+      "resolved": "packages/ai-sdk",
       "link": true
     },
     "node_modules/@zensation/algorithms": {
@@ -842,6 +921,24 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.83",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.83.tgz",
+      "integrity": "sha512-bg7+SopUwqA7DeQ2O8I9qELyQTHCeeI/0RuNUlT/gGz+LqWrIl5vbYRQv3eMBEnUsVFaM33n6SA8Vqe9gi8L1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.67",
+        "@ai-sdk/provider": "4.0.8",
+        "@ai-sdk/provider-utils": "5.0.32"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2135,6 +2232,13 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3606,6 +3710,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "dev": true,
@@ -3908,6 +4022,27 @@
       },
       "peerDependencies": {
         "@zensation/core": "^0.2.0 || ^0.3.0"
+      }
+    },
+    "packages/ai-sdk": {
+      "name": "@zensation/ai-sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@ai-sdk/provider": "^4.0.8",
+        "@zensation/adapter-sqlite": "^0.2.1",
+        "@zensation/core": "^0.3.1",
+        "ai": "^7.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@ai-sdk/provider": "^3.0.0 || ^4.0.0",
+        "@zensation/core": "^0.3.0",
+        "ai": "^6.0.0 || ^7.0.0"
       }
     },
     "packages/algorithms": {

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -1,0 +1,140 @@
+# @zensation/ai-sdk
+
+**Status: 0.1.0, early release.** The option shape may still change before 1.0. The memory
+layers underneath are the ones the [ZenBrain paper](https://arxiv.org/abs/2604.23878)
+describes and the
+[benchmarks](https://github.com/zensation-ai/zenbrain/blob/main/docs/benchmarks.md) measure.
+
+ZenBrain as [Vercel AI SDK](https://ai-sdk.dev) middleware. Recall what is relevant before
+the model call, store the turn after it. Works with any provider the AI SDK supports,
+because it never touches the provider.
+
+```bash
+npm install @zensation/ai-sdk @zensation/core @zensation/adapter-sqlite
+```
+
+```typescript
+import { generateText, wrapLanguageModel } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { MemoryCoordinator } from '@zensation/core';
+import { SqliteAdapter } from '@zensation/adapter-sqlite';
+import { zenbrainMemory } from '@zensation/ai-sdk';
+
+const coordinator = new MemoryCoordinator({
+  storage: new SqliteAdapter({ filename: './memory.db' }),
+});
+
+const model = wrapLanguageModel({
+  model: openai('gpt-5'),
+  middleware: zenbrainMemory({ coordinator }),
+});
+
+await generateText({ model, prompt: 'Anna moved to Hamburg in March.' });
+
+// A later call, possibly days later, in a different process:
+const { text } = await generateText({ model, prompt: 'Where does Anna live?' });
+```
+
+Between the two calls nothing was passed by hand. The second prompt arrives at the model
+with a system message in front of it:
+
+```
+Relevant memories from earlier sessions:
+- Anna moved to Hamburg in March.
+```
+
+## Zero runtime dependencies
+
+The middleware is a plain object; `wrapLanguageModel` is called by you. Nothing here is
+imported from `ai` at runtime — only its types are. So this package installs **nothing**:
+
+| Package | Runtime dependencies |
+|---|--:|
+| `@zensation/ai-sdk` | **0** |
+| `@zensation/core` | 1 (`@zensation/algorithms`) |
+| `@zensation/algorithms` | **0** |
+
+That claim is [checked in CI on every push](https://github.com/zensation-ai/zenbrain/blob/main/scripts/verify-zero-dependencies.sh)
+against the packed tarballs rather than the source tree.
+
+## Options
+
+```typescript
+zenbrainMemory({
+  coordinator,                     // required — you own its lifecycle
+
+  recall: {                        // or false to switch searching off
+    limit: 5,                      // how many memories to inject
+    layers: ['semantic', 'core'],  // which layers to search
+    minConfidence: 0.6,            // drop anything below this
+    taskType: 'coding',            // context-dependent retrieval hint
+  },
+
+  store: {                         // or false to switch writing off
+    user: true,                    // store the user's message (default)
+    assistant: false,              // store the reply too (default off)
+    context: 'work',               // context domain for what gets stored
+  },
+
+  header: 'Relevant memories from earlier sessions:',
+
+  onError: (err, phase) => console.warn(`[zenbrain] ${phase} failed`, err),
+});
+```
+
+### Two defaults worth knowing
+
+**Replies are not stored by default.** A model's answer is derived from the question and
+cheap to regenerate; storing both sides doubles the volume and fills semantic memory with
+your own model's phrasing. Turn it on with `store: { assistant: true }` when the answer
+carries information the question does not.
+
+**Failures are swallowed.** If recall or store throws, the call goes through anyway,
+unmodified. A memory layer that breaks a chat is worse than one that forgets. Pass
+`onError` to see what is being hidden — without it, failures are silent by design.
+
+## Where the memory lands
+
+Routing on store is automatic: a general statement becomes a semantic fact, a narrated
+event an episode, a sequence of instructions a procedure. Which layer a memory lands in
+decides how it decays and whether it survives consolidation. The seven layers, their
+retention rules and the algorithms behind them are documented in the
+[main README](https://github.com/zensation-ai/zenbrain#readme).
+
+Consolidation does not run on its own. Call `coordinator.consolidate()` on a schedule that
+suits your application.
+
+## What this release does not do
+
+- **No embedding provider is configured unless you pass one.** Semantic search then runs
+  without vectors: recall still works, less sharply than the benchmarked configuration.
+- **Streaming stores on flush.** The reply is written once the stream completes. An aborted
+  stream stores the user's turn but not the partial answer.
+- **Only text is read.** File and tool parts of a message are ignored when building the
+  recall query and when storing.
+- **One recall per call.** There is no re-retrieval mid-generation.
+
+## Streaming
+
+`streamText` works the same way and passes the stream through untouched:
+
+```typescript
+const result = streamText({
+  model: wrapLanguageModel({
+    model: openai('gpt-5'),
+    middleware: zenbrainMemory({ coordinator, store: { assistant: true } }),
+  }),
+  prompt: 'Which theme should I use?',
+});
+
+for await (const chunk of result.textStream) process.stdout.write(chunk);
+```
+
+## Links
+
+- Repository: <https://github.com/zensation-ai/zenbrain>
+- Paper: <https://arxiv.org/abs/2604.23878>
+- MCP server (same memory, for Claude Desktop and Cursor): [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp)
+- Playground: <https://zensation.ai/en/playground>
+
+Apache-2.0.

--- a/packages/ai-sdk/__tests__/middleware.test.ts
+++ b/packages/ai-sdk/__tests__/middleware.test.ts
@@ -1,0 +1,301 @@
+/**
+ * These tests wrap a real model with the real `wrapLanguageModel` and read what the
+ * model actually received. A middleware that returns a well-formed object but never
+ * reaches the prompt would pass a shape test and do nothing in production.
+ *
+ * The coordinator is a stub here, on purpose: `InMemoryStorage` cannot round-trip
+ * content (it stores parameters as `col_0`, `col_1`, …), so it can prove nothing about
+ * injection. The real round trip is covered in `sqlite-integration.test.ts`.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { generateText, streamText, wrapLanguageModel } from 'ai';
+import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
+import type { MemoryCoordinator, RecallResult } from '@zensation/core';
+import { zenbrainMemory } from '../src/index.js';
+
+/** A coordinator that records what it was asked and returns what the test dictates. */
+function stubCoordinator(recallResults: Partial<RecallResult>[] = []) {
+  const stored: { content: string; options: unknown }[] = [];
+  const recalls: { query: string; options: unknown }[] = [];
+  const coordinator = {
+    async store(content: string, options: unknown) {
+      stored.push({ content, options });
+      return `id-${stored.length}`;
+    },
+    async recall(query: string, options: unknown) {
+      recalls.push({ query, options });
+      return recallResults as RecallResult[];
+    },
+  } as unknown as MemoryCoordinator;
+  return { coordinator, stored, recalls };
+}
+
+const reply = (text: string) => ({
+  content: [{ type: 'text' as const, text }],
+  finishReason: 'stop' as const,
+  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+  warnings: [],
+});
+
+function systemTexts(prompt: readonly { role: string; content: unknown }[]): string[] {
+  return prompt.filter((m) => m.role === 'system').map((m) => String(m.content));
+}
+
+describe('recall injection', () => {
+  it('puts recalled memories in front of the model', async () => {
+    const { coordinator, recalls } = stubCoordinator([
+      { content: 'The user prefers dark mode.', layer: 'semantic', score: 0.9 },
+      { content: 'The user works in Kiel.', layer: 'semantic', score: 0.7 },
+    ]);
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      prompt: 'What theme should I use?',
+    });
+
+    const systems = systemTexts(model.doGenerateCalls[0].prompt);
+    expect(systems.length).toBe(1);
+    expect(systems[0]).toContain('dark mode');
+    expect(systems[0]).toContain('Kiel');
+    expect(systems[0]).toContain('Relevant memories');
+
+    // The query has to be the user's message, not the whole conversation.
+    expect(recalls[0].query).toBe('What theme should I use?');
+  });
+
+  it('leaves the caller\'s own system prompt with the last word', async () => {
+    const { coordinator } = stubCoordinator([
+      { content: 'A memory.', layer: 'semantic', score: 1 },
+    ]);
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      system: 'You are terse.',
+      prompt: 'Hello',
+    });
+
+    const prompt = model.doGenerateCalls[0].prompt;
+    expect(prompt[0].role).toBe('system');
+    expect(String(prompt[0].content)).toContain('A memory.');
+    expect(systemTexts(prompt).some((s) => s.includes('You are terse.'))).toBe(true);
+    // ours first, the caller's after it
+    expect(systemTexts(prompt)[1]).toBe('You are terse.');
+  });
+
+  it('injects nothing when nothing was recalled', async () => {
+    const { coordinator } = stubCoordinator([]);
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      prompt: 'Hello',
+    });
+
+    expect(systemTexts(model.doGenerateCalls[0].prompt)).toEqual([]);
+  });
+
+  it('drops rows whose content did not survive the storage adapter', async () => {
+    const { coordinator } = stubCoordinator([
+      { layer: 'semantic', score: 0.5 } as Partial<RecallResult>, // no content
+      { content: 'A real one.', layer: 'semantic', score: 0.4 },
+    ]);
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      prompt: 'Hello',
+    });
+
+    const injected = systemTexts(model.doGenerateCalls[0].prompt)[0];
+    expect(injected).toContain('A real one.');
+    expect(injected).not.toContain('- \n');
+    expect(injected.split('\n').filter((l) => l.startsWith('- ')).length).toBe(1);
+  });
+
+  it('honours limit, layers and a custom header', async () => {
+    const { coordinator, recalls } = stubCoordinator([
+      { content: 'x', layer: 'core', score: 1 },
+    ]);
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({
+        model,
+        middleware: zenbrainMemory({
+          coordinator,
+          recall: { limit: 3, layers: ['core'], minConfidence: 0.5 },
+          header: 'What I remember:',
+        }),
+      }),
+      prompt: 'Hello',
+    });
+
+    expect(recalls[0].options).toMatchObject({ limit: 3, layers: ['core'], minConfidence: 0.5 });
+    expect(systemTexts(model.doGenerateCalls[0].prompt)[0]).toContain('What I remember:');
+  });
+
+  it('does not search at all when recall is switched off', async () => {
+    const { coordinator, recalls } = stubCoordinator([
+      { content: 'never used', layer: 'semantic', score: 1 },
+    ]);
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({
+        model,
+        middleware: zenbrainMemory({ coordinator, recall: false }),
+      }),
+      prompt: 'Hello',
+    });
+
+    expect(recalls).toHaveLength(0);
+    expect(systemTexts(model.doGenerateCalls[0].prompt)).toEqual([]);
+  });
+});
+
+describe('storing the turn', () => {
+  it('stores the user message by default and the reply only on request', async () => {
+    const { coordinator, stored } = stubCoordinator();
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('Use dark mode.') });
+
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      prompt: 'Which theme?',
+    });
+    expect(stored.map((s) => s.content)).toEqual(['Which theme?']);
+
+    const second = stubCoordinator();
+    const model2 = new MockLanguageModelV4({ doGenerate: async () => reply('Use dark mode.') });
+    await generateText({
+      model: wrapLanguageModel({
+        model: model2,
+        middleware: zenbrainMemory({
+          coordinator: second.coordinator,
+          store: { assistant: true, context: 'work' },
+        }),
+      }),
+      prompt: 'Which theme?',
+    });
+    expect(second.stored.map((s) => s.content)).toEqual(['Which theme?', 'Use dark mode.']);
+    expect(second.stored[0].options).toMatchObject({ context: 'work', source: 'user' });
+    expect(second.stored[1].options).toMatchObject({ context: 'work', source: 'ai' });
+  });
+
+  it('writes nothing when storing is switched off', async () => {
+    const { coordinator, stored } = stubCoordinator();
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator, store: false }) }),
+      prompt: 'Hello',
+    });
+
+    expect(stored).toHaveLength(0);
+  });
+});
+
+describe('streaming', () => {
+  it('passes the stream through unchanged and stores what was said', async () => {
+    const { coordinator, stored } = stubCoordinator();
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Use ' },
+            { type: 'text-delta', id: '1', delta: 'dark ' },
+            { type: 'text-delta', id: '1', delta: 'mode.' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 1, outputTokens: 3, totalTokens: 4 },
+            },
+          ],
+        }),
+      }),
+    });
+
+    const result = streamText({
+      model: wrapLanguageModel({
+        model,
+        middleware: zenbrainMemory({ coordinator, store: { assistant: true } }),
+      }),
+      prompt: 'Which theme?',
+    });
+
+    let text = '';
+    for await (const part of result.textStream) text += part;
+
+    // The reader sees exactly what the model sent.
+    expect(text).toBe('Use dark mode.');
+    // And both sides of the turn were written once the stream finished.
+    expect(stored.map((s) => s.content)).toEqual(['Which theme?', 'Use dark mode.']);
+  });
+});
+
+describe('failure is contained', () => {
+  it('answers normally when recall throws, and reports it', async () => {
+    const onError = vi.fn();
+    const coordinator = {
+      async recall() {
+        throw new Error('storage is down');
+      },
+      async store() {
+        return 'id';
+      },
+    } as unknown as MemoryCoordinator;
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('still here') });
+
+    const out = await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator, onError }) }),
+      prompt: 'Hello',
+    });
+
+    expect(out.text).toBe('still here');
+    expect(systemTexts(model.doGenerateCalls[0].prompt)).toEqual([]);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), 'recall');
+  });
+
+  it('answers normally when storing throws, and reports it', async () => {
+    const onError = vi.fn();
+    const coordinator = {
+      async recall() {
+        return [];
+      },
+      async store() {
+        throw new Error('disk full');
+      },
+    } as unknown as MemoryCoordinator;
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('still here') });
+
+    const out = await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator, onError }) }),
+      prompt: 'Hello',
+    });
+
+    expect(out.text).toBe('still here');
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), 'store');
+  });
+
+  it('stays silent when no onError was given', async () => {
+    const coordinator = {
+      async recall() {
+        throw new Error('boom');
+      },
+      async store() {
+        throw new Error('boom');
+      },
+    } as unknown as MemoryCoordinator;
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('fine') });
+
+    const out = await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      prompt: 'Hello',
+    });
+    expect(out.text).toBe('fine');
+  });
+});

--- a/packages/ai-sdk/__tests__/sqlite-integration.test.ts
+++ b/packages/ai-sdk/__tests__/sqlite-integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The middleware over the storage a user actually gets.
+ *
+ * `middleware.test.ts` proves the contract against a stub coordinator. This proves the
+ * one thing a stub cannot: that something stored in an earlier turn comes back into the
+ * next prompt, through a real coordinator and a real SQLite file.
+ *
+ * Needs Node >= 22, because `better-sqlite3` 13 does. The version gate sits before the
+ * import: on an unsupported runtime that module does not throw, it takes the worker down.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { generateText, wrapLanguageModel } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+import { MemoryCoordinator, FakeEmbeddingProvider, InMemoryCache } from '@zensation/core';
+import { zenbrainMemory } from '../src/index.js';
+
+const NODE_MAJOR = Number(process.versions.node.split('.')[0]);
+const SUPPORTED = NODE_MAJOR >= 22;
+
+let sqlite: typeof import('@zensation/adapter-sqlite') | undefined;
+if (SUPPORTED) {
+  sqlite = await import('@zensation/adapter-sqlite');
+} else {
+  process.stderr.write(
+    `\n[sqlite-integration] SKIPPED — Node ${process.version} is below the engines floor ` +
+      `of >= 22 that better-sqlite3 13 requires. This suite is expected to RUN in CI ` +
+      `(22, 24, 26); a green local run here proves nothing about it.\n\n`,
+  );
+}
+
+const open: typeof describe.skip = sqlite ? describe : describe.skip;
+
+let coordinator: MemoryCoordinator | undefined;
+afterEach(async () => {
+  await coordinator?.close();
+  coordinator = undefined;
+});
+
+const reply = (text: string) => ({
+  content: [{ type: 'text' as const, text }],
+  finishReason: 'stop' as const,
+  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+  warnings: [],
+});
+
+open('the middleware over a real SQLite store', () => {
+  it('carries a memory from one turn into the next prompt', async () => {
+    coordinator = new MemoryCoordinator({
+      storage: new sqlite!.SqliteAdapter({ filename: ':memory:' }),
+      embedding: new FakeEmbeddingProvider(),
+      cache: new InMemoryCache(),
+    });
+
+    const middleware = zenbrainMemory({ coordinator, store: { assistant: false } });
+
+    // Turn one: the user says something worth keeping. Nothing to recall yet.
+    const first = new MockLanguageModelV4({ doGenerate: async () => reply('Noted.') });
+    await generateText({
+      model: wrapLanguageModel({ model: first, middleware }),
+      prompt: 'Anna moved to Hamburg in March.',
+    });
+    expect(first.doGenerateCalls[0].prompt.filter((m) => m.role === 'system')).toHaveLength(0);
+
+    // Turn two: a different question, same subject. The first turn must come back.
+    const second = new MockLanguageModelV4({ doGenerate: async () => reply('Hamburg.') });
+    await generateText({
+      model: wrapLanguageModel({ model: second, middleware }),
+      prompt: 'Where does Anna live?',
+    });
+
+    const injected = second.doGenerateCalls[0].prompt
+      .filter((m) => m.role === 'system')
+      .map((m) => String(m.content));
+
+    expect(injected).toHaveLength(1);
+    expect(injected[0]).toContain('Hamburg');
+  });
+
+  it('actually persists the turn, not just the prompt', async () => {
+    coordinator = new MemoryCoordinator({
+      storage: new sqlite!.SqliteAdapter({ filename: ':memory:' }),
+      embedding: new FakeEmbeddingProvider(),
+      cache: new InMemoryCache(),
+    });
+
+    const model = new MockLanguageModelV4({ doGenerate: async () => reply('ok') });
+    await generateText({
+      model: wrapLanguageModel({ model, middleware: zenbrainMemory({ coordinator }) }),
+      prompt: 'Redis listens on port 6379.',
+    });
+
+    // Ask the coordinator directly — the middleware is not in this path at all.
+    const found = await coordinator.recall('Redis port', { limit: 5 });
+    expect(found.length).toBeGreaterThan(0);
+    expect(found.some((r) => typeof r.content === 'string' && r.content.includes('6379'))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@zensation/ai-sdk",
+  "version": "0.1.0",
+  "description": "ZenBrain as Vercel AI SDK middleware: recall relevant memories before a model call, store the turn after it. Zero runtime dependencies.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "vercel-ai-sdk",
+    "ai-sdk",
+    "ai-sdk-middleware",
+    "zenbrain",
+    "agent-memory",
+    "ai-memory",
+    "memory-layer",
+    "long-term-memory",
+    "episodic-memory",
+    "stateful-agents",
+    "llm-memory"
+  ],
+  "author": "ZenSation <open-source@zensation.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zensation-ai/zenbrain.git",
+    "directory": "packages/ai-sdk"
+  },
+  "homepage": "https://github.com/zensation-ai/zenbrain/tree/main/packages/ai-sdk#readme",
+  "engines": {
+    "node": ">=22"
+  },
+  "peerDependencies": {
+    "@ai-sdk/provider": "^3.0.0 || ^4.0.0",
+    "@zensation/core": "^0.3.0",
+    "ai": "^6.0.0 || ^7.0.0"
+  },
+  "devDependencies": {
+    "@ai-sdk/provider": "^4.0.8",
+    "@zensation/adapter-sqlite": "^0.2.1",
+    "@zensation/core": "^0.3.1",
+    "ai": "^7.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -1,0 +1,211 @@
+/**
+ * @zensation/ai-sdk
+ *
+ * ZenBrain as Vercel AI SDK middleware: recall before the model call, store after it.
+ *
+ * The middleware is a plain object — `wrapLanguageModel` is called by *you*, not by this
+ * package. That is why nothing here is imported from `ai` at runtime; only its types are.
+ * The package therefore ships with zero runtime dependencies, like the rest of the core
+ * chain.
+ */
+import type {
+  LanguageModelV4CallOptions,
+  LanguageModelV4Message,
+  LanguageModelV4Middleware,
+  LanguageModelV4StreamPart,
+} from '@ai-sdk/provider';
+import type { MemoryCoordinator, RecallOptions, StoreOptions } from '@zensation/core';
+
+/** Layers the coordinator understands, repeated here so callers get completion. */
+export type MemoryLayer = 'working' | 'episodic' | 'semantic' | 'procedural' | 'core';
+
+export interface ZenBrainMemoryOptions {
+  /** A live MemoryCoordinator. This package never creates or closes one. */
+  coordinator: MemoryCoordinator;
+
+  /** How to search before each call. Set to `false` to disable recall entirely. */
+  recall?:
+    | false
+    | {
+        /** Maximum memories to inject. Default 5. */
+        limit?: number;
+        /** Restrict the search to these layers. */
+        layers?: MemoryLayer[];
+        /** Drop memories below this confidence. */
+        minConfidence?: number;
+        /** Current task type, used for context-dependent retrieval. */
+        taskType?: string;
+      };
+
+  /** What to write back after each call. Set to `false` to disable writing. */
+  store?:
+    | false
+    | {
+        /** Store the user's message. Default true. */
+        user?: boolean;
+        /** Store the model's reply. Default false — replies are cheap to regenerate. */
+        assistant?: boolean;
+        /** Context domain for stored memories, e.g. 'work'. */
+        context?: string;
+        /** Source attribution. Defaults to 'user' / 'ai' per turn. */
+        source?: string;
+      };
+
+  /**
+   * The line placed above the recalled memories in the injected system message.
+   * Keep it short; it is spent from the same context budget as the memories.
+   */
+  header?: string;
+
+  /**
+   * Called when recall or store throws. Defaults to swallowing the error, because a
+   * memory layer that breaks a chat is worse than one that forgets. Pass your logger
+   * here to see what it is hiding.
+   */
+  onError?: (error: unknown, phase: 'recall' | 'store') => void;
+}
+
+const DEFAULT_HEADER = 'Relevant memories from earlier sessions:';
+const DEFAULT_LIMIT = 5;
+
+/** Pulls the plain text out of one prompt message, ignoring files and tool parts. */
+function messageText(message: LanguageModelV4Message | undefined): string {
+  if (!message) return '';
+  if (message.role === 'system') return typeof message.content === 'string' ? message.content : '';
+  if (!Array.isArray(message.content)) return '';
+  return message.content
+    .filter((part): part is { type: 'text'; text: string } => {
+      const p = part as { type?: unknown; text?: unknown };
+      return p.type === 'text' && typeof p.text === 'string';
+    })
+    .map((part) => part.text)
+    .join('\n')
+    .trim();
+}
+
+/** The last message from the user, which is what a recall should be about. */
+function lastUserText(prompt: readonly LanguageModelV4Message[]): string {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    if (prompt[i].role === 'user') return messageText(prompt[i]);
+  }
+  return '';
+}
+
+/**
+ * Builds the middleware.
+ *
+ * ```ts
+ * const model = wrapLanguageModel({
+ *   model: openai('gpt-5'),
+ *   middleware: zenbrainMemory({ coordinator }),
+ * });
+ * ```
+ */
+export function zenbrainMemory(options: ZenBrainMemoryOptions): LanguageModelV4Middleware {
+  const { coordinator, onError } = options;
+  const recallOpts = options.recall === false ? false : (options.recall ?? {});
+  const storeOpts = options.store === false ? false : (options.store ?? {});
+  const header = options.header ?? DEFAULT_HEADER;
+
+  const report = (err: unknown, phase: 'recall' | 'store'): void => {
+    if (onError) onError(err, phase);
+  };
+
+  /** Writes one turn back into memory. Never throws into the caller's request. */
+  const remember = async (userText: string, assistantText: string): Promise<void> => {
+    if (storeOpts === false) return;
+    const base: StoreOptions = {};
+    if (storeOpts.context !== undefined) base.context = storeOpts.context;
+
+    try {
+      if (storeOpts.user !== false && userText) {
+        await coordinator.store(userText, { ...base, source: storeOpts.source ?? 'user' });
+      }
+      if (storeOpts.assistant === true && assistantText) {
+        await coordinator.store(assistantText, { ...base, source: storeOpts.source ?? 'ai' });
+      }
+    } catch (err) {
+      report(err, 'store');
+    }
+  };
+
+  return {
+    specificationVersion: 'v4',
+
+    async transformParams({ params }): Promise<LanguageModelV4CallOptions> {
+      if (recallOpts === false) return params;
+
+      const query = lastUserText(params.prompt);
+      if (!query) return params;
+
+      let memories: string[];
+      try {
+        const search: RecallOptions = { limit: recallOpts.limit ?? DEFAULT_LIMIT };
+        if (recallOpts.layers) search.layers = recallOpts.layers;
+        if (recallOpts.minConfidence !== undefined) search.minConfidence = recallOpts.minConfidence;
+        if (recallOpts.taskType !== undefined) search.taskType = recallOpts.taskType;
+
+        const results = await coordinator.recall(query, search);
+        // `content` is typed as required but assembled from whatever the storage
+        // adapter returned. A row that lost it must not produce a blank bullet.
+        memories = results
+          .filter((r) => typeof r.content === 'string' && r.content.length > 0)
+          .map((r) => `- ${r.content}`);
+      } catch (err) {
+        report(err, 'recall');
+        return params;
+      }
+
+      // Nothing recalled means nothing to inject. Never spend context on an empty header.
+      if (memories.length === 0) return params;
+
+      const memoryMessage: LanguageModelV4Message = {
+        role: 'system',
+        content: `${header}\n${memories.join('\n')}`,
+      };
+
+      // Prepended, so the caller's own system prompt keeps the last word.
+      return { ...params, prompt: [memoryMessage, ...params.prompt] };
+    },
+
+    async wrapGenerate({ doGenerate, params }) {
+      const result = await doGenerate();
+
+      const userText = lastUserText(params.prompt);
+      const assistantText = result.content
+        .filter((c): c is { type: 'text'; text: string } => {
+          const p = c as { type?: unknown; text?: unknown };
+          return p.type === 'text' && typeof p.text === 'string';
+        })
+        .map((c) => c.text)
+        .join('')
+        .trim();
+
+      await remember(userText, assistantText);
+      return result;
+    },
+
+    async wrapStream({ doStream, params }) {
+      const result = await doStream();
+      const userText = lastUserText(params.prompt);
+
+      // The reply only exists once the stream has run, so accumulate the deltas and
+      // write on flush. The stream is passed through unchanged — a memory layer must
+      // not sit between the model and the screen.
+      let assistantText = '';
+      const capture = new TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart>({
+        transform(chunk, controller) {
+          if (chunk.type === 'text-delta' && typeof chunk.delta === 'string') {
+            assistantText += chunk.delta;
+          }
+          controller.enqueue(chunk);
+        },
+        async flush() {
+          await remember(userText, assistantText.trim());
+        },
+      });
+
+      return { ...result, stream: result.stream.pipeThrough(capture) };
+    },
+  };
+}

--- a/packages/ai-sdk/tsconfig.json
+++ b/packages/ai-sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/ai-sdk/vitest.config.ts
+++ b/packages/ai-sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Adds `@zensation/ai-sdk`: recall relevant memories before a model call, store the turn after it. Works with any provider the AI SDK supports, because it never touches the provider.

```ts
const model = wrapLanguageModel({
  model: openai('gpt-5'),
  middleware: zenbrainMemory({ coordinator }),
});
```

### Why this docking point

Measured 28.08.2026: `ai` sits at **89,980,629 downloads/month** on npm, second only to the MCP SDK. And it converts into visible adoption — `@mem0/vercel-ai-provider` has **238 dependent repositories** on 25k downloads/month, which is a better ratio than mem0's own main package.

### Zero runtime dependencies

The middleware is a plain object; `wrapLanguageModel` is called by the user. Nothing is imported from `ai` at runtime, only its types. So the package installs **nothing**.

| | Runtime dependencies |
|---|--:|
| `@zensation/ai-sdk` | **0** |
| `@mem0/vercel-ai-provider` | 11, including five model providers, pinned to `ai@^6` while the SDK is at 7.0.83 |

`scripts/verify-zero-dependencies.sh` still passes unchanged.

### Two defaults that are decisions, not oversights

- **Replies are not stored.** An answer is derived from the question and cheap to regenerate; storing both sides doubles volume and fills semantic memory with our own model's phrasing. `store: { assistant: true }` opts in.
- **Failures are swallowed** and the call proceeds unmodified. A memory layer that breaks a chat is worse than one that forgets. `onError` surfaces what is hidden; without it the silence is deliberate. Both paths are tested.

### How this is verified

Twelve tests wrap a real model with the real `wrapLanguageModel` and assert on `model.doGenerateCalls[0].prompt` — **what the model actually received**, not what the middleware returned. A middleware that produces a well-formed object but never reaches the prompt would pass a shape test and do nothing in production.

Covered: injection · ordering against the caller's own system prompt · empty recall injects nothing · rows with no content are dropped · limit/layers/header pass through · `recall: false` never searches · `store: false` never writes · assistant on/off · **stream passes through unchanged while the text is accumulated and stored on flush** · recall throws · store throws · no `onError` given.

Two more run the same path against a real SQLite store and prove a memory from turn one arrives in turn two's prompt. Gated on Node >= 22 **before** the import, for the same reason as in `packages/mcp`.

### Lockfile

Regenerated in this commit. Leaving it stale in [#63](https://github.com/zensation-ai/zenbrain/pull/63) broke `npm ci` for anyone cloning the repo and cost [#65](https://github.com/zensation-ai/zenbrain/pull/65) to fix.

### Before publishing

Needs a **trusted publisher for `@zensation/ai-sdk`** on npmjs.com, which npm only allows after a first publish ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). The publish step is last in the job so a missing publisher cannot take the established packages down.