### PR TITLE
fix(mcp): fail with a message on old Node instead of segfaulting silently

### DIFF
--- a/packages/mcp/__tests__/node-guard.test.ts
+++ b/packages/mcp/__tests__/node-guard.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The runtime guard on the bin entry.
+ *
+ * Measured before it existed: on Node 20 the binary exits **139 (SIGSEGV) with
+ * an empty stdout and an empty stderr** — better-sqlite3's native module loads
+ * and then crashes the process the moment `new SqliteAdapter()` runs. `engines`
+ * only makes npm print a warning, and an MCP client surfaces none of that, so
+ * the server just never comes up and the user has nothing to go on.
+ *
+ * The check is a pure function over a version string so it can be tested on any
+ * runtime, rather than only on the one where the crash happens.
+ */
+import { describe, it, expect } from 'vitest';
+import { unsupportedNodeMessage } from '../src/index.js';
+
+describe('the Node version guard', () => {
+  it('passes every supported runtime', () => {
+    for (const v of ['v22.0.0', 'v22.11.0', 'v24.3.1', 'v26.0.0', 'v30.1.2', '22.11.0']) {
+      expect(unsupportedNodeMessage(v), `${v} should be accepted`).toBeNull();
+    }
+  });
+
+  it('rejects every runtime below the engines floor', () => {
+    for (const v of ['v18.20.4', 'v20.20.2', 'v21.7.3', '20.0.0']) {
+      expect(unsupportedNodeMessage(v), `${v} should be rejected`).not.toBeNull();
+    }
+  });
+
+  it('names the runtime it found and the one it needs', () => {
+    const msg = unsupportedNodeMessage('v20.20.2');
+    expect(msg).toContain('v20.20.2');
+    expect(msg).toContain('Node 22 or newer');
+  });
+
+  it('tells the user what to do, not just what is wrong', () => {
+    const msg = unsupportedNodeMessage('v20.20.2')!;
+    expect(msg).toMatch(/command/);
+    expect(msg).toMatch(/dist\/index\.js/);
+  });
+
+  it('rejects a version string it cannot parse rather than waving it through', () => {
+    for (const v of ['', 'not-a-version', 'vNaN']) {
+      expect(unsupportedNodeMessage(v), `${v} should not be treated as supported`).not.toBeNull();
+    }
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Model Context Protocol server for ZenBrain — gives any MCP client a 7-layer memory: store, recall, consolidate, inspect.",
   "mcpName": "ai.zensation/zenbrain",
   "type": "module",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -15,14 +15,51 @@
  * transport. Diagnostics go to stderr.
  */
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { MemoryCoordinator } from '@zensation/core';
-import { SqliteAdapter } from '@zensation/adapter-sqlite';
 import { createZenBrainServer } from './server.js';
 
 export { createZenBrainServer } from './server.js';
 export type { ZenBrainServerOptions } from './server.js';
 
+/** Lowest Node this package supports, mirroring `engines.node` in package.json. */
+const MIN_NODE_MAJOR = 22;
+
+/**
+ * `engines` only makes npm print a warning, and an MCP client shows the user
+ * nothing at all. On Node 20 the storage adapter's native module loads and then
+ * segfaults the moment it is instantiated — exit 139, no stdout, no stderr. From
+ * the client's side the server simply never comes up, with nothing to go on.
+ *
+ * So check before anything native is reachable, and say what is wrong.
+ */
+export function unsupportedNodeMessage(version: string): string | null {
+  const major = Number(version.replace(/^v/, '').split('.')[0]);
+  if (Number.isFinite(major) && major >= MIN_NODE_MAJOR) return null;
+
+  return (
+    `zenbrain-mcp needs Node ${MIN_NODE_MAJOR} or newer — this is Node ${version}.\n` +
+    `Its SQLite storage uses better-sqlite3, whose native module crashes on older\n` +
+    `runtimes instead of failing cleanly. Upgrade Node, or point your MCP client at a\n` +
+    `Node ${MIN_NODE_MAJOR}+ binary:\n\n` +
+    `  { "command": "/path/to/node22/bin/node",\n` +
+    `    "args": ["/path/to/node_modules/@zensation/mcp/dist/index.js"] }\n`
+  );
+}
+
+function assertSupportedNode(): void {
+  const message = unsupportedNodeMessage(process.version);
+  if (message === null) return;
+  process.stderr.write(message);
+  process.exit(1);
+}
+
 async function main(): Promise<void> {
+  assertSupportedNode();
+
+  // Imported here, not at module scope: a static import is hoisted above the
+  // check and would load the native module before we get to say anything.
+  const { MemoryCoordinator } = await import('@zensation/core');
+  const { SqliteAdapter } = await import('@zensation/adapter-sqlite');
+
   const filename = process.env.ZENBRAIN_DB ?? './zenbrain.db';
   const contexts = process.env.ZENBRAIN_CONTEXTS?.split(',')
     .map((c) => c.trim())


### PR DESCRIPTION
Found while accepting the freshly published `@zensation/mcp@0.1.0` **at the artifact on npm** rather than at the local build.

## The failure

Installed from the registry, run on Node 20:

```
$ node node_modules/@zensation/mcp/dist/index.js
exit 139   stdout 0 bytes   stderr 0 bytes
```

Exit 139 is SIGSEGV. Bisected: the module *loads* — `better-sqlite3` imports cleanly, so does the adapter — and the process dies on `new SqliteAdapter({filename:':memory:'})`. Native ABI mismatch, which is exactly why the package declares `engines.node >= 22`.

**But `engines` only makes npm print a warning**, and an MCP client shows the user none of it. From Claude Desktop or Cursor the server simply never comes up, with nothing in any log. For the package meant to be our front door, that is the worst possible first contact — and Node 20 was LTS until recently.

## The fix

A version check that runs **before anything native is reachable**. The two storage imports move into `main()` as dynamic imports, because a static import is hoisted above the check and would load the native module first.

Same command, same runtime, after:

```
exit 1
zenbrain-mcp needs Node 22 or newer — this is Node v20.20.2.
Its SQLite storage uses better-sqlite3, whose native module crashes on older
runtimes instead of failing cleanly. Upgrade Node, or point your MCP client at a
Node 22+ binary:

  { "command": "/path/to/node22/bin/node",
    "args": ["/path/to/node_modules/@zensation/mcp/dist/index.js"] }
```

## Tests

The check is a pure function over a version string, so it is testable on **any** runtime rather than only on the one where the crash happens — 5 cases over supported (`22, 24, 26, 30`), unsupported (`18, 20, 21`) and unparsable (`""`, `"not-a-version"`) versions. The last group matters: an unparsable version must not be waved through.

`packages/mcp`: 17 passed, 4 skipped locally (the SQLite suite needs Node 22; it runs in CI).

Version 0.1.0 → 0.1.1.