### PR TITLE
npm: carry the measured result on every package page

### DIFF
--- a/packages/adapters/postgres/README.md
+++ b/packages/adapters/postgres/README.md
@@ -91,6 +91,6 @@ accuracy at 1/106th of the per-query token cost.
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
 - Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
-- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 
 License: Apache-2.0

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/adapter-postgres",
   "version": "0.2.1",
-  "description": "PostgreSQL + pgvector storage adapter for ZenBrain memory system.",
+  "description": "PostgreSQL + pgvector storage adapter for ZenBrain memory system. Server-backed persistence with vector similarity search in the database.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/adapters/sqlite/README.md
+++ b/packages/adapters/sqlite/README.md
@@ -64,6 +64,6 @@ accuracy at 1/106th of the per-query token cost.
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
 - Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
-- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 
 License: Apache-2.0

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -130,11 +130,17 @@ const result = streamText({
 for await (const chunk of result.textStream) process.stdout.write(chunk);
 ```
 
-## Links
+## About ZenBrain
 
-- Repository: <https://github.com/zensation-ai/zenbrain>
-- Paper: <https://arxiv.org/abs/2604.23878>
-- MCP server (same memory, for Claude Desktop and Cursor): [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp)
-- Playground: <https://zensation.ai/en/playground>
+ZenBrain is a seven-layer, neuroscience-derived memory architecture for LLM agents, built as
+zero-dependency TypeScript and published under Apache-2.0. On LongMemEval-500 it wins all nine
+head-to-head answer-quality comparisons against Letta, Mem0 and A-Mem (three competitors x three
+LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's binary-judge
+accuracy at 1/106th of the per-query token cost.
 
-Apache-2.0.
+- Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
+
+License: Apache-2.0

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/ai-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZenBrain as Vercel AI SDK middleware: recall relevant memories before a model call, store the turn after it. Zero runtime dependencies.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/algorithms/README.md
+++ b/packages/algorithms/README.md
@@ -258,6 +258,6 @@ accuracy at 1/106th of the per-query token cost.
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
 - Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
-- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 
 License: Apache-2.0

--- a/packages/algorithms/package.json
+++ b/packages/algorithms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/algorithms",
   "version": "0.4.1",
-  "description": "ZenBrain's open-source memory algorithm library: 10 core algorithms (FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation, Bayesian confidence, ...) + 10 advanced research modules (vmPFC-FSRS, two-factor Hebbian, simulation-selection sleep, Fiedler-value KG health, Information-Bottleneck budget, Hopfield STM, Personalized PageRank, ...). 20 modules, zero dependencies.",
+  "description": "ZenBrain's memory algorithms as a standalone library: FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation and 15 more. 20 modules, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,6 +87,6 @@ accuracy at 1/106th of the per-query token cost.
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
 - Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
-- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 
 License: Apache-2.0

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -116,11 +116,18 @@ SDK, so it carries one. Keeping it in its own package is what lets the core stay
 installing `@zensation/core` never pulls the MCP SDK, and installing this never weakens
 the claim the core makes.
 
-## Links
+## About ZenBrain
 
-- Repository: <https://github.com/zensation-ai/zenbrain>
-- Paper: <https://arxiv.org/abs/2604.23878>
-- Playground: <https://zensation.ai/en/playground>
+ZenBrain is a seven-layer, neuroscience-derived memory architecture for LLM agents, built as
+zero-dependency TypeScript and published under Apache-2.0. On LongMemEval-500 it wins all nine
+head-to-head answer-quality comparisons against Letta, Mem0 and A-Mem (three competitors x three
+LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's binary-judge
+accuracy at 1/106th of the per-query token cost.
+
+- Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
+- Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 - Registry entry: `ai.zensation/zenbrain`
 
-Apache-2.0.
+License: Apache-2.0


### PR DESCRIPTION
Audit of the npm surface — all seven published packages, measured against the registry API (the website returns 403 to anonymous clients).

## What the audit found

| Check | Result |
|---|---|
| Forbidden vocabulary (first/pioneer, battle-tested, GDPR-native, naked 47.7, 12/12, venue names) | **0 hits across all seven** |
| Scanner control probe (planted violation) | catches all five classes — the zero is a measurement, not a blind instrument |
| Licence declared | Apache-2.0 on all seven |
| Provenance | on the four published via CI; absent on `mcp`/`ai-sdk`, which had to be published by hand for the trusted publisher to exist at all |
| **The nine head-to-head wins** | 🔴 **absent from every published README** |
| Repository link | missing on both adapters and on `cli` |
| Package list | named four packages; there are six |

The four zenbrain packages already carry the result on `main` and pick it up with the next tag. **`@zensation/mcp` and `@zensation/ai-sdk` did not carry it at all** — they pointed at the paper rather than stating the measurement, on the two pages meant to be the front door.

## What this changes

- The canonical **About ZenBrain** passage, word-for-word identical to the one in `core` and `algorithms`, added to both new packages. Identical wording is the point: a differing form splits the entity.
- Package list lifted to **six** in all six READMEs.
- `@zensation/algorithms` description: **416 → 196** characters. It ran past what npm search shows and used `…` ellipses mid-sentence; same search terms, readable result.
- `@zensation/adapter-postgres` description: **65 → 138**. It said less than sqlite's did, with no reason for the asymmetry.
- `ai-sdk` 0.1.0 → **0.1.1**, since 0.1.0 is already on the registry and the README only travels with a version.

## Verification

Forbidden-list grep re-run over all six changed READMEs: **0 hits**, control probe still catching. Both gates green. `mcp` 17 passed / 4 skipped, `ai-sdk` 12 / 2, `core` 99 passed.