### PR TITLE
chore(mcp): server.json to 0.1.1, matching npm and the registry

### DIFF
--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@zensation/mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The MCP registry entry is live:

```
name        ai.zensation/zenbrain
version     0.1.1        status: active
package     @zensation/mcp 0.1.1 (npm)
repository  github.com/zensation-ai/zenbrain, subfolder packages/mcp
```

Published against the `zensation.ai` TXT record, so the namespace is ours by domain proof rather than by claim. `server.json` still said 0.1.0 — the next publish would have registered a version older than the one already live.