### PR TITLE
npm: put the words people search for into the two descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] — 2026-08-29
+
+**Metadata only. No runtime code changed** — `packages/*/src` is byte-identical to `0.4.1`.
+`@zensation/mcp` and `@zensation/ai-sdk` move `0.1.1 → 0.1.2`; the other four are untouched.
+
+### Changed — the npm descriptions of the two integration packages
+
+npm's search ranks on the words in a package's `description`, and it weighs that far above
+download counts. For the query `vercel ai sdk memory`, `@turbomem/vercel-ai` (142 downloads a
+month) ranks first and `ai` (90,669,436 downloads a month) second. Of the fifteen top results
+for `mcp memory`, three carry no keywords at all; what all fifteen have in common is those two
+words standing next to each other in a name or a description.
+
+Neither of these packages had that. `@zensation/mcp` said *"gives any MCP client a 7-layer
+memory"* and `@zensation/ai-sdk` said *"recall relevant memories before a model call"* — both
+accurate, and neither in the top 250 for any phrase someone looking for this would actually
+type, while `@mem0/vercel-ai-provider`, the direct counterpart to `@zensation/ai-sdk`, sits at
+39. The new descriptions put the phrases together and claim nothing new:
+
+- `@zensation/mcp` — "MCP memory server for ZenBrain: agent memory for any Model Context Protocol client — store, recall, consolidate, health. Local SQLite file, no account."
+- `@zensation/ai-sdk` — "Vercel AI SDK memory middleware: agent memory that recalls before a model call and stores the turn after it. Zero runtime dependencies."
+
+Whether this moves anything is an open question, and it is measured the same way it was found:
+the same queries, re-run, with `7-layer memory` → `@zensation/core` at rank 1 as the control
+that the instrument still works.
+
+### Fixed — documentation that had drifted from what is published
+
+- The old `@zensation/mcp` description named a tool `inspect`. There is no such tool. The four
+  are `zenbrain_store`, `zenbrain_recall`, `zenbrain_consolidate` and `zenbrain_health`.
+- The package table in the README listed `@zensation/mcp` and `@zensation/ai-sdk` as
+  `:construction: Unreleased`. Both have been on npm with provenance attestations since
+  2026-08-28.
+- Both package READMEs opened with *"Status: 0.1.0, early release"* while `0.1.1` was the
+  published version. The version number is out of the sentence — the status was the point, and
+  a pinned number there only ages.
+- `@zensation/ai-sdk` did not appear in this changelog at all. It is Vercel AI SDK middleware:
+  it recalls before the model call and stores the turn after it, carries zero runtime
+  dependencies, and its twelve tests assert on `doGenerateCalls[0].prompt` — what reached the
+  model — rather than on what the middleware returned.
+
 ## [0.4.1] — 2026-08-28
 
 **Two things: a new package, and a metadata-only republish of the existing four.**

--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ const dueItems = await memory.getReviewQueue();
 | [`@zensation/core`](./packages/core) | Memory layers, coordinator, adapter interfaces | :white_check_mark: Published |
 | [`@zensation/adapter-postgres`](./packages/adapters/postgres) | PostgreSQL + pgvector storage adapter | :white_check_mark: Published |
 | [`@zensation/adapter-sqlite`](./packages/adapters/sqlite) | SQLite storage adapter (zero-config) | :white_check_mark: Published |
-| [`@zensation/mcp`](./packages/mcp) | MCP server — gives any MCP client (Claude Desktop, Claude Code, Cursor) the seven layers as four tools. Carries the protocol SDK, so the core stays dependency-free | :construction: Unreleased |
-| [`@zensation/ai-sdk`](./packages/ai-sdk) | Vercel AI SDK middleware — recall before the model call, store after it. Works with any provider, **zero runtime dependencies** | :construction: Unreleased |
+| [`@zensation/mcp`](./packages/mcp) | MCP server — gives any MCP client (Claude Desktop, Claude Code, Cursor) the seven layers as four tools. Carries the protocol SDK, so the core stays dependency-free | :white_check_mark: Published |
+| [`@zensation/ai-sdk`](./packages/ai-sdk) | Vercel AI SDK middleware — recall before the model call, store after it. Works with any provider, **zero runtime dependencies** | :white_check_mark: Published |
 
 ### Tree-Shakeable Imports
 

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -1,6 +1,6 @@
 # @zensation/ai-sdk
 
-**Status: 0.1.0, early release.** The option shape may still change before 1.0. The memory
+**Status: early release.** The option shape may still change before 1.0. The memory
 layers underneath are the ones the [ZenBrain paper](https://arxiv.org/abs/2604.23878)
 describes and the
 [benchmarks](https://github.com/zensation-ai/zenbrain/blob/main/docs/benchmarks.md) measure.

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/ai-sdk",
-  "version": "0.1.1",
-  "description": "ZenBrain as Vercel AI SDK middleware: recall relevant memories before a model call, store the turn after it. Zero runtime dependencies.",
+  "version": "0.1.2",
+  "description": "Vercel AI SDK memory middleware: agent memory that recalls before a model call and stores the turn after it. Zero runtime dependencies.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @zensation/mcp
 
-**Status: 0.1.0, early release.** The tool surface is small on purpose and may still
+**Status: early release.** The tool surface is small on purpose and may still
 change before 1.0. The memory layers underneath it are the same ones the
 [ZenBrain paper](https://arxiv.org/abs/2604.23878) describes and the
 [benchmarks](https://github.com/zensation-ai/zenbrain/blob/main/docs/benchmarks.md) measure.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/mcp",
-  "version": "0.1.1",
-  "description": "Model Context Protocol server for ZenBrain — gives any MCP client a 7-layer memory: store, recall, consolidate, inspect.",
+  "version": "0.1.2",
+  "description": "MCP memory server for ZenBrain: agent memory for any Model Context Protocol client — store, recall, consolidate, health. Local SQLite file, no account.",
   "mcpName": "ai.zensation/zenbrain",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.1.1",
+  "version": "0.1.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@zensation/mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Metadata only. `packages/*/src` is byte-identical to `v0.4.1` — verified by diff, with a positive control on `CHANGELOG.md`/`README.md` so an empty result could not be a broken instrument.

## Why

npm search ranks on the words in a package `description`, and it weighs that **far above download counts**:

| query `vercel ai sdk memory` | rank | downloads/month |
|---|--:|--:|
| `@turbomem/vercel-ai` | **1** | **142** |
| `ai` (Vercel AI SDK) | 2 | **90,669,436** |

Of the fifteen top results for `mcp memory`, **three carry no keywords at all**. What all fifteen share is those two words standing **next to each other** in a name or a description.

Neither integration package had that. `@zensation/mcp` said *"gives any MCP client a 7-layer memory"*, `@zensation/ai-sdk` said *"recall relevant memories before a model call"* — both accurate, and neither in the top 250 for any phrase someone looking for this would type. `@mem0/vercel-ai-provider`, the direct counterpart to `@zensation/ai-sdk`, sits at 39.

Controls that were run before this was called a finding: searching `zenbrain` returns **all seven** packages at their current versions, so absence is not search-index lag; and `7-layer memory` returns `@zensation/core` at **rank 1 of 139,782**, so a distinctive phrase in a description can win a large field.

## What changes

| package | new description |
|---|---|
| `@zensation/mcp` | MCP memory server for ZenBrain: agent memory for any Model Context Protocol client — store, recall, consolidate, health. Local SQLite file, no account. |
| `@zensation/ai-sdk` | Vercel AI SDK memory middleware: agent memory that recalls before a model call and stores the turn after it. Zero runtime dependencies. |

Both `0.1.1 → 0.1.2`. `packages/mcp/server.json` tracks the version in both of its fields.

## Fixed on the way

- The old `mcp` description named a tool **`inspect`**. There is no such tool — the fourth is `zenbrain_health`.
- The README package table listed both packages as `:construction: Unreleased`. Both have been on npm with provenance since 2026-08-28.
- Both package READMEs opened with *"Status: 0.1.0, early release"* while `0.1.1` was published. The number is out of the sentence — a pinned version there only ages.
- `@zensation/ai-sdk` was **not in the changelog at all**.

## How this gets judged

Same queries, re-run after publish, with `7-layer memory` → `@zensation/core` rank 1 as the control that the instrument still works. No movement means the hypothesis is wrong and the item closes for good.