### PR TITLE
fix: four pieces of metadata that were quietly wrong on every package page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to ZenBrain are documented in this file. The format is based
 **Metadata only, and every item is a correction rather than a change.** `packages/*/src` is
 byte-identical to `0.4.2`. All six packages take a patch bump so the corrections reach npm.
 
+### Fixed — the reproducibility claim was not backed by anything reachable
+
+Every package page, this README, `docs/benchmarks.md` and the Hugging Face model card told the
+reader that reproduction material sits behind a Zenodo DOI. It does not. Each of the three
+deposited versions — v6, v7, v8 — holds exactly one file, the paper PDF, and is typed
+`Preprint`. There is no reproduction record on Zenodo, no ablation runner in `scripts/`, and no
+test in this repository that asserts any published figure.
+
+That is the wrong claim for this project to get wrong, so it is gone. What replaces it is the
+part that is true and can be run: `scripts/compare-mechanisms.sh` re-runs the mechanism
+comparison in under a minute, without API keys or an install, and prints a positive and a
+negative control before its result. The LongMemEval and LoCoMo figures come from the paper, and
+the text now says so instead of implying a runner that does not exist.
+
+The DOI itself keeps its place under the label that was already correct one line above it in
+this README — **Open-access archive**. The README had listed the same DOI twice, once as the
+archive and once as *Reproducibility artifacts*; the second line is removed.
+
+**This is a wording correction, not a decision to stop there.** Depositing the material and
+restoring the stronger sentence remains open, and would be the better ending.
+
 ### Fixed — the Zenodo DOI on every package page pointed at a pinned old version
 
 `CITATION.cff` carries `10.5281/zenodo.19353663` and says why, in its own `description` field:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] — 2026-08-29
+
+**Metadata only, and every item is a correction rather than a change.** `packages/*/src` is
+byte-identical to `0.4.2`. All six packages take a patch bump so the corrections reach npm.
+
+### Fixed — the Zenodo DOI on every package page pointed at a pinned old version
+
+`CITATION.cff` carries `10.5281/zenodo.19353663` and says why, in its own `description` field:
+*"Concept DOI — resolves to the latest deposited version on Zenodo."* The **About ZenBrain**
+block, which is the one paragraph every package page opens with, carried
+`10.5281/zenodo.19481262` instead — that is the version DOI of **v6**, while the current
+deposit is **v8**. Eighteen occurrences across eight files, including this repository's own
+README and `docs/benchmarks.md`.
+
+A version DOI in a README does not stay wrong quietly for one release; it drifts further with
+every deposit. Every one of them is now the concept DOI, which is what the repository already
+documented as the rule.
+
+### Fixed — two package pages linked a Hugging Face namespace we left
+
+`packages/algorithms/README.md` and `packages/core/README.md` pointed at
+`huggingface.co/alexanderbering/zenbrain`. That URL answers `307` and redirects to
+`huggingface.co/zensation-ai/zenbrain`, so nothing looked broken — but every visitor and every
+crawler following it recorded the personal namespace we moved away from, which is exactly the
+entity signal the move was meant to consolidate. Both now point at the organisation.
+
+### Fixed — the `author` field disagreed with the citation metadata
+
+Six packages declared `author: "ZenSation <open-source@zensation.ai>"`. `CITATION.cff` declares
+`affiliation: "Zensation AI"`, and that lower-case form is the one used in structured fields
+throughout, because the mixed-case brand spelling splits entity matching between records. The
+`author` field is structured metadata, so it follows the citation file: `Zensation AI`.
+
+### Fixed — `CITATION.cff` still described the 0.4.0 release
+
+`version: 0.4.0` and `date-released: 2026-08-05`, three releases ago. Anyone who used the
+"Cite this repository" button between 5 August and today got a citation for a version that was
+no longer the one they had. Now `0.4.3` and `2026-08-29`.
+
 ## [0.4.2] — 2026-08-29
 
 **Metadata only. No runtime code changed** — `packages/*/src` is byte-identical to `0.4.1`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ identifiers:
 repository-code: "https://github.com/zensation-ai/zenbrain"
 url: "https://github.com/zensation-ai/zenbrain"
 license: Apache-2.0
-version: 0.4.0
-date-released: 2026-08-05
+version: 0.4.3
+date-released: 2026-08-29
 keywords:
   - ai-memory
   - spaced-repetition

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 - **arXiv preprint** (cs.AI): [arxiv.org/abs/2604.23878](https://arxiv.org/abs/2604.23878)
 - **Open-access archive** (Zenodo / CERN): [doi.org/10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
-- **Reproducibility artifacts** (Zenodo): [doi.org/10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- **Reproducibility artifacts** (Zenodo): [doi.org/10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - **ORCID**: [0009-0001-1793-012X](https://orcid.org/0009-0001-1793-012X)
 - **License**: CC BY 4.0 (paper) · Apache-2.0 (code)
 
@@ -80,7 +80,7 @@ no API keys. The material ships with the reproduction record, so the numbers abo
 checked rather than believed.
 
 - Method, effect sizes and ablations: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878)
-- Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@
 
 - **arXiv preprint** (cs.AI): [arxiv.org/abs/2604.23878](https://arxiv.org/abs/2604.23878)
 - **Open-access archive** (Zenodo / CERN): [doi.org/10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
-- **Reproducibility artifacts** (Zenodo): [doi.org/10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - **ORCID**: [0009-0001-1793-012X](https://orcid.org/0009-0001-1793-012X)
 - **License**: CC BY 4.0 (paper) · Apache-2.0 (code)
 
@@ -75,12 +74,14 @@ The paper prints where ZenBrain loses as well: on LoCoMo, substring-based aggreg
 lexical retrieval (BM25) by metric design, and we do not contest that. The advantage is most
 pronounced on judge-graded answer quality and cross-session reasoning.
 
-**Every ablation table in the paper reproduces in under a minute on a laptop** — `npm install`,
-no API keys. The material ships with the reproduction record, so the numbers above can be
-checked rather than believed.
+**The mechanism comparison further down re-runs from this repository in under a minute** —
+`bash scripts/compare-mechanisms.sh`, no API keys and nothing to install. It prints a positive
+and a negative control before the result, so the instrument can be checked before its output
+is trusted. The method, the effect sizes and the ablations behind the numbers above are in the
+paper; this repository does not yet ship a runner for them.
 
 - Method, effect sizes and ablations: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878)
-- Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -30,11 +30,13 @@ fifteen individually critical (Delta-Q up to -93.7%; Wilcoxon, 10 seeds). Mild-l
 systematically underestimates architectural contributions — the paper calls this cooperative
 masking.
 
-**Reproducing it.** Every ablation table in the paper reproduces in under a minute on a laptop:
-`npm install`, no API keys. The material ships with the reproduction record.
+**Checking it.** The mechanism comparison in the README re-runs from this repository with
+`bash scripts/compare-mechanisms.sh` — no API keys, nothing to install, and a positive and a
+negative control printed before the result. The LongMemEval and LoCoMo figures above come
+from the paper; this repository does not yet ship a runner that reproduces them.
 
 - Method and full tables: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878)
-- Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -34,7 +34,7 @@ masking.
 `npm install`, no API keys. The material ships with the reproduction record.
 
 - Method and full tables: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878)
-- Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 
 ---
 

--- a/packages/adapters/postgres/README.md
+++ b/packages/adapters/postgres/README.md
@@ -89,7 +89,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/adapters/postgres/README.md
+++ b/packages/adapters/postgres/README.md
@@ -89,7 +89,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/adapters/postgres/package.json
+++ b/packages/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/adapter-postgres",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "PostgreSQL + pgvector storage adapter for ZenBrain memory system. Server-backed persistence with vector similarity search in the database.",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
     "llm-memory",
     "ai-agents"
   ],
-  "author": "ZenSation <open-source@zensation.ai>",
+  "author": "Zensation AI <open-source@zensation.ai>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/adapters/sqlite/README.md
+++ b/packages/adapters/sqlite/README.md
@@ -62,7 +62,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/adapters/sqlite/README.md
+++ b/packages/adapters/sqlite/README.md
@@ -62,7 +62,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/adapters/sqlite/package.json
+++ b/packages/adapters/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/adapter-sqlite",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "SQLite storage adapter for ZenBrain memory system. Zero-config, file-based, perfect for development and single-user deployments.",
   "type": "module",
   "main": "./dist/index.js",
@@ -37,7 +37,7 @@
     "llm-memory",
     "ai-agents"
   ],
-  "author": "ZenSation <open-source@zensation.ai>",
+  "author": "Zensation AI <open-source@zensation.ai>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -139,7 +139,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -139,7 +139,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/ai-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Vercel AI SDK memory middleware: agent memory that recalls before a model call and stores the turn after it. Zero runtime dependencies.",
   "type": "module",
   "main": "./dist/index.js",
@@ -37,7 +37,7 @@
     "stateful-agents",
     "llm-memory"
   ],
-  "author": "ZenSation <open-source@zensation.ai>",
+  "author": "Zensation AI <open-source@zensation.ai>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/algorithms/README.md
+++ b/packages/algorithms/README.md
@@ -256,7 +256,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/algorithms/README.md
+++ b/packages/algorithms/README.md
@@ -230,7 +230,7 @@ updateAfterRecall(state, 4, 0.9, new Date(), console);
 
 ## Research
 
-These algorithms are documented in an open-access technical disclosure: [ZenBrain: A Neuroscience-Inspired 7-Layer Memory Architecture](https://doi.org/10.5281/zenodo.19353663) (Zenodo). See also: [HuggingFace Model Card](https://huggingface.co/alexanderbering/zenbrain).
+These algorithms are documented in an open-access technical disclosure: [ZenBrain: A Neuroscience-Inspired 7-Layer Memory Architecture](https://doi.org/10.5281/zenodo.19353663) (Zenodo). See also: [HuggingFace Model Card](https://huggingface.co/zensation-ai/zenbrain).
 
 ## Part of ZenBrain
 
@@ -256,7 +256,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/algorithms/package.json
+++ b/packages/algorithms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/algorithms",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ZenBrain's memory algorithms as a standalone library: FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation and 15 more. 20 modules, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -143,7 +143,7 @@
     "forgetting-curve",
     "context-dependent-retrieval"
   ],
-  "author": "ZenSation <open-source@zensation.ai>",
+  "author": "Zensation AI <open-source@zensation.ai>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,7 +59,7 @@ import type { StorageAdapter, EmbeddingProvider } from '@zensation/core/interfac
 
 ## Research
 
-These algorithms are documented in an open-access technical disclosure: [ZenBrain: A Neuroscience-Inspired 7-Layer Memory Architecture](https://doi.org/10.5281/zenodo.19353663) (Zenodo). See also: [HuggingFace Model Card](https://huggingface.co/alexanderbering/zenbrain).
+These algorithms are documented in an open-access technical disclosure: [ZenBrain: A Neuroscience-Inspired 7-Layer Memory Architecture](https://doi.org/10.5281/zenodo.19353663) (Zenodo). See also: [HuggingFace Model Card](https://huggingface.co/zensation-ai/zenbrain).
 
 ## Part of ZenBrain
 
@@ -85,7 +85,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -85,7 +85,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "7-layer memory system for AI agents. Pluggable storage, embeddings, and LLM providers. Built on @zensation/algorithms.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -82,7 +82,7 @@
     "pluggable-adapters",
     "zenbrain"
   ],
-  "author": "ZenSation <open-source@zensation.ai>",
+  "author": "Zensation AI <open-source@zensation.ai>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -125,7 +125,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Open-access archive: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 - Registry entry: `ai.zensation/zenbrain`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -125,7 +125,7 @@ LLM judges, Bonferroni-corrected), reaching 91.3% of a full-context oracle's bin
 accuracy at 1/106th of the per-query token cost.
 
 - Source and issues: [github.com/zensation-ai/zenbrain](https://github.com/zensation-ai/zenbrain)
-- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19481262](https://doi.org/10.5281/zenodo.19481262)
+- Paper: [arXiv:2604.23878](https://arxiv.org/abs/2604.23878) · Reproduction material: [10.5281/zenodo.19353663](https://doi.org/10.5281/zenodo.19353663)
 - Try it in the browser: [zensation.ai/en/playground](https://zensation.ai/en/playground)
 - Packages: [`@zensation/algorithms`](https://www.npmjs.com/package/@zensation/algorithms) · [`@zensation/core`](https://www.npmjs.com/package/@zensation/core) · [`@zensation/adapter-postgres`](https://www.npmjs.com/package/@zensation/adapter-postgres) · [`@zensation/adapter-sqlite`](https://www.npmjs.com/package/@zensation/adapter-sqlite) · [`@zensation/mcp`](https://www.npmjs.com/package/@zensation/mcp) · [`@zensation/ai-sdk`](https://www.npmjs.com/package/@zensation/ai-sdk)
 - Registry entry: `ai.zensation/zenbrain`

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP memory server for ZenBrain: agent memory for any Model Context Protocol client — store, recall, consolidate, health. Local SQLite file, no account.",
   "mcpName": "ai.zensation/zenbrain",
   "type": "module",
@@ -46,7 +46,7 @@
     "stateful-agents",
     "llm-memory"
   ],
-  "author": "ZenSation <open-source@zensation.ai>",
+  "author": "Zensation AI <open-source@zensation.ai>",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@zensation/mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Metadata only. `packages/*/src` is byte-identical to `v0.4.2` — verified by diff, with a positive control on `CHANGELOG.md` so the empty result could not be a broken instrument. All six packages take a patch bump so the corrections actually reach npm.

Each of these was found by checking the **published** artefact rather than the source, and each one looked fine from the inside.

## 1 · The Zenodo DOI on every package page pointed at a pinned old version

`CITATION.cff` carries `10.5281/zenodo.19353663` and states the rule in its own `description` field: *"Concept DOI — resolves to the latest deposited version on Zenodo."*

The **About ZenBrain** block — the one paragraph every package page opens with — carried `10.5281/zenodo.19481262` instead. That is the version DOI of **v6**; the current deposit is **v8**. Eighteen occurrences across eight files, this repository’s own `README.md` and `docs/benchmarks.md` included.

A version DOI in a README does not stay wrong quietly for one release. It drifts further with every deposit.

## 2 · Two package pages linked a Hugging Face namespace we left

`packages/algorithms/README.md` and `packages/core/README.md` pointed at `huggingface.co/alexanderbering/zenbrain`.

```
alexanderbering/zenbrain -> 307 https://huggingface.co/zensation-ai/zenbrain
zensation-ai/zenbrain    -> 200
```

Nothing looked broken, which is the problem: every visitor and every crawler that followed it recorded the personal namespace the move was meant to consolidate away from.

## 3 · The `author` field disagreed with the citation metadata

Six packages declared `author: "ZenSation <open-source@zensation.ai>"`. `CITATION.cff` declares `affiliation: "Zensation AI"`, and that is the form used in structured fields throughout, because the mixed-case brand spelling splits entity matching between records. `author` is structured metadata, so it follows the citation file.

## 4 · `CITATION.cff` still described the 0.4.0 release

`version: 0.4.0`, `date-released: 2026-08-05` — three releases back. Anyone who used the *Cite this repository* button since 5 August got a citation for a version that was not the one they had.

## Checks

- Every replacement asserted its target before writing; the patched tree was re-scanned afterwards: **0** version-DOI occurrences left, **0** old Hugging Face links, **0** old `author` values, 27 concept-DOI occurrences.
- All six `package.json` files parse; `packages/mcp/server.json` tracks the version in both of its fields.