### PR TITLE
docs: say where the benchmark numbers come from

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,7 +1,10 @@
 # ZenBrain Benchmarks
 
-This file collects the algorithm-level micro-benchmarks that run inside this repository.
-The system-level result — the one the architecture is judged on — is LongMemEval-500, below.
+This file collects the numbers behind ZenBrain. The system-level result — the one the
+architecture is judged on — is LongMemEval-500, below. The algorithm-level figures under it are
+a mix: some are measured, and some are taken from the published literature, cited at the table
+that uses them. Neither kind runs from a script in this repository; the one thing that does is
+`scripts/compare-mechanisms.sh`.
 
 ## LongMemEval-500 (system level)
 


### PR DESCRIPTION
`docs/benchmarks.md` opened with *"the algorithm-level micro-benchmarks that run inside this repository."*

They do not run here. There is no bench script — the root `package.json` has `build`, `test`, `lint`, `clean` — and the tables under that heading are largely cited rather than measured: *FSRS vs SM-2* comes from [open-spaced-repetition/fsrs4anki](https://github.com/open-spaced-repetition/fsrs4anki), the emotional-memory boost from LaBar & Cabeza (2006) and Cahill & McGaugh (1998). Others are measurements taken elsewhere and reported here.

Same class as the reproducibility wording corrected in `v0.4.3`: a sentence that promises the reader a run they cannot perform. The opening now says which figures are measured, which are cited, and names the one thing that does run from this repository — `scripts/compare-mechanisms.sh`.

Documentation only; no package version changes.