### PR TITLE
Fix the tarball claim, and hold it with a check

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ These aren't toy implementations — ZenBrain's algorithms are extracted from [Z
 
 - **528 tests** (429 algorithms + 99 core), all passing
 - **Zero runtime dependencies** — pure TypeScript, dual ESM + CJS, tree-shakeable subpath exports
-- **Reproducible** — building from this source produces the same 152-file `@zensation/algorithms@0.4.0` tarball published on npm
+- **Reproducible** — building from this source produces the same 153-file `@zensation/algorithms@0.4.2` tarball published on npm
 - **7-layer** memory architecture grounded in published neuroscience
 
 ## Contributing

--- a/scripts/verify-package-contents.sh
+++ b/scripts/verify-package-contents.sh
@@ -47,6 +47,11 @@ for pkg in "${PACKAGES[@]}"; do
     grep -q "^package/$entry" <<<"$listing" || missing+=("files:$entry")
   done < <(node -p "(require('$ROOT/$pkg/package.json').files||[]).join('\n')")
 
+  if [ "$pkg" = "packages/algorithms" ]; then
+    algorithms_files=$(grep -vc '/$' <<<"$listing")
+    algorithms_version=$(node -p "require('$ROOT/$pkg/package.json').version")
+  fi
+
   if [ ${#missing[@]} -eq 0 ]; then
     echo "OK"
   else
@@ -63,3 +68,32 @@ if [ "$fail" -ne 0 ]; then
 fi
 
 echo "Every package ships its licence, its README and everything \`files\` claims."
+
+# The README makes a reproducible-build claim with a number in it:
+#   "the same 153-file `@zensation/algorithms@0.4.2` tarball published on npm"
+# A count in a sentence is an invariant, not a counter — it goes false the next
+# time we ship, and nothing notices. It already did: the claim sat at 152 files
+# and 0.4.0 through two releases. This holds the sentence to the packed tarball.
+claim=$(grep -oE '[0-9]+-file `@zensation/algorithms@[0-9]+\.[0-9]+\.[0-9]+`' "$ROOT/README.md" || true)
+
+if [ -z "$claim" ]; then
+  echo
+  echo "README: the reproducible-build claim is gone or reworded."
+  echo "Either restore it in the form '<N>-file \`@zensation/algorithms@<version>\`'"
+  echo "or drop this check with it."
+  exit 1
+fi
+
+claimed_files=${claim%%-file*}
+claimed_version=${claim##*@}
+claimed_version=${claimed_version%\`}
+
+echo
+if [ "$claimed_files" != "$algorithms_files" ] || [ "$claimed_version" != "$algorithms_version" ]; then
+  echo "README claims a ${claimed_files}-file tarball for algorithms@${claimed_version}."
+  echo "Packing packages/algorithms actually gives ${algorithms_files} files at ${algorithms_version}."
+  echo "Update the sentence in README.md, or explain why the build stopped being reproducible."
+  exit 1
+fi
+
+echo "README's ${claimed_files}-file claim for algorithms@${claimed_version} matches the packed tarball."


### PR DESCRIPTION
The README says the build is reproducible and names a number:

> building from this source produces the same **152-file** `@zensation/algorithms@**0.4.0**` tarball published on npm

That was true when it was written. npm has shipped `0.4.1` and `0.4.2` since, both with **153** files. Anyone checking the sentence against the registry today finds a different version and a different count.

**Measured on the published artefact, with two instruments:**

| | `tar -tzf` on the tarball | registry `dist.fileCount` |
|---|--:|--:|
| `algorithms@0.4.0` | 152 | 152 |
| `algorithms@0.4.2` | **153** | **153** |
| `core@0.3.2` (control) | 82 | 82 |

**What is *not* wrong:** the test counts in the same block. CI run 33248532670 (`976d7b4`) reports **429** for algorithms and **99** for core on Node 22, 24 and 26 — exactly the `528 tests (429 + 99)` the README claims. Left untouched.

### Why the second commit

Nothing was checking this number, so it rotted silently through two releases. A count written into a sentence is an invariant, not a counter: it goes false precisely when we do the right thing and ship.

`scripts/verify-package-contents.sh` already exists to turn a `files` claim into one we can keep. This extends it to the one number the README states about the tarball. It fails three ways:

- wrong count
- wrong version
- **claim quietly removed** — so deleting the sentence cannot buy a green run

Verified against all four cases in isolation, including the `152`/`0.4.0` state that prompted this: it goes red on exactly that input. The script already runs in CI (`ci.yml:85`).

Local build/test could not be run here — this machine has Node 20 and the workspace requires >=22 — so the end-to-end proof is this PR's own CI run.