### PR TITLE
algorithms 0.4.4: description leads with agent memory (npm ranking field)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to ZenBrain are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] — 2026-09-01
+
+**`@zensation/algorithms` only, description only.** `src` is byte-identical to `0.4.2`; no other
+package is bumped (the publish step skips versions already on the registry).
+
+### Changed
+
+- The package description now says what the library is for — *agent memory for LLM agents* —
+  before listing how it works. The npm search ranks by word sequences in the description, and
+  the previous text never contained the phrase people actually search for. Same correction the
+  GitHub repository description received on 2026-08-29.
+
 ## [0.4.3] — 2026-08-29
 
 **Metadata only, and every item is a correction rather than a change.** `packages/*/src` is

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ These aren't toy implementations — ZenBrain's algorithms are extracted from [Z
 
 - **528 tests** (429 algorithms + 99 core), all passing
 - **Zero runtime dependencies** — pure TypeScript, dual ESM + CJS, tree-shakeable subpath exports
-- **Reproducible** — building from this source produces the same 153-file `@zensation/algorithms@0.4.2` tarball published on npm
+- **Reproducible** — building from this source produces the same 153-file `@zensation/algorithms@0.4.4` tarball published on npm
 - **7-layer** memory architecture grounded in published neuroscience
 
 ## Contributing

--- a/packages/algorithms/package.json
+++ b/packages/algorithms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/algorithms",
-  "version": "0.4.2",
-  "description": "ZenBrain's memory algorithms as a standalone library: FSRS spaced repetition, Hebbian learning, Ebbinghaus decay, emotional tagging, sleep consolidation and 15 more. 20 modules, zero dependencies.",
+  "version": "0.4.4",
+  "description": "Agent memory for LLM agents: FSRS spaced repetition, Hebbian learning, Ebbinghaus forgetting curves, emotional tagging, sleep consolidation and 15 more. ZenBrain's algorithm core — 20 modules, zero-dependency TypeScript library.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
Description-only patch release. npm ranks by word sequences in the description (measured 29.08 + 01.09; mechanics in the PR-repo canon). The flagship package never contained the phrase "agent memory". src byte-identical to 0.4.2. Straight to 0.4.4 - the 0.4.3 slot is taken by the 29.08 metadata wave (tag exists, algorithms was not bumped in it). After merge: tag v0.4.4 -> OIDC publish (idempotent, only algorithms is new).