### PR TITLE
cite: point the software DOI at the software record

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,16 +9,16 @@ authors:
     affiliation: "Zensation AI"
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.19353663
-    description: "Concept DOI — resolves to the latest deposited version on Zenodo"
+    value: 10.5281/zenodo.22260018
+    description: "Concept DOI of the software record on Zenodo — resolves to the latest deposited source release"
   - type: other
     value: "arXiv:2604.23878"
     description: "arXiv preprint identifier (cs.AI)"
 repository-code: "https://github.com/zensation-ai/zenbrain"
 url: "https://github.com/zensation-ai/zenbrain"
 license: Apache-2.0
-version: 0.4.3
-date-released: 2026-08-29
+version: 0.4.4
+date-released: 2026-09-01
 keywords:
   - ai-memory
   - spaced-repetition


### PR DESCRIPTION
CITATION.cff declares `type: software`, but its `doi` identifier resolved to the **paper's** concept DOI — citing the software yielded a preprint.

A dedicated software record now exists on Zenodo:

- **Concept DOI** [10.5281/zenodo.22260018](https://doi.org/10.5281/zenodo.22260018) (resolves to the latest deposited source release)
- Version DOI [10.5281/zenodo.22260019](https://doi.org/10.5281/zenodo.22260019) for **v0.4.4**, pinning tag v0.4.4 (commit 871c451e), the source tarball (SHA-256 `c0bc60cb…5631`) and the npm dist hash of `@zensation/algorithms@0.4.4`
- `resource_type: software`, `isSupplementTo` → paper concept DOI

Changes here: `identifiers[doi]` → 22260018, `version` 0.4.3 → 0.4.4, `date-released` → 2026-09-01. **`preferred-citation` keeps the paper with the paper DOI — unchanged.**