### PR TITLE
mcp 0.1.4: republish so the npm search index gets a download snapshot

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensation/mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP memory server for ZenBrain: agent memory for any Model Context Protocol client — store, recall, consolidate, health. Local SQLite file, no account.",
   "mcpName": "ai.zensation/zenbrain",
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@zensation/mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
A version bump and nothing else. **No description, no keywords, no README, no repository field is touched** — that is the whole point.

## Why a release with no content change

The npm search index stores a **download snapshot taken at publish time** (`index.updated` = `modified` + 20–31 s, measured across all seven packages in the scope). The downloads API lags about six days, so a package published for the first time reads structurally **0** and keeps `searchScore 0` until it is published again. It then never appears in any ranking, no matter what its description says.

Measured 2026-09-04, a three-step staircase:

| package | last publish | value in the search index |
|---|---|---|
| `algorithms` | republished 01.09. | **978** |
| `core` | 29.08. | **234** (live value at the time: 644) |
| `mcp`, `ai-sdk` | never republished | **not findable at all** |

Corpus control over ~1,500 ranked result rows: **no row** with a monthly value of 0; the lowest ranked value was 6. Only the zero is fatal — the height does not order.

## The negative control stays put

`ai-sdk` deliberately stays at **0.1.3**.

- If `mcp` moves and `ai-sdk` does not → a global reindex is ruled out as the explanation.
- If neither moves → the hypothesis is dead and npm is closed as a discovery surface for these two packages. That is a useful outcome too.

This is why no text field may be touched: a second variable would make the result unreadable.

## Why `server.json` moves along

It carries the same version twice and **ships inside the tarball** (it is listed in the package's `files` array). Leaving it behind would put a manifest claiming `0.1.3` inside the `0.1.4` artifact. It is the same number in a second place, not a second change.
The public MCP registry currently holds two entries for `ai.zensation/zenbrain` (`0.1.1` and `0.1.3`) — it accumulates versions. Publishing there is a separate act and is **not** part of this PR.

## Preconditions checked before opening this

- **Trusted publishing works for this package.** `@zensation/mcp@0.1.3` carries provenance attestations, as do `core`, `algorithms` and `ai-sdk`. Control: `lodash` reports none, so the check discriminates. This matters because the publisher is configured **per package** and the job stops at the first failure — on 2026-08-05 exactly that produced a half release.
- **The other packages will skip.** Each publish step queries `npm view <pkg>@<version>` first and skips when the version already exists. Only `mcp` changes version, so only `mcp` publishes.
- **Tag convention read from history, not invented:** the tag is a running release counter independent of which packages move — `v0.4.2` bumped only ai-sdk + mcp, `v0.4.4` only algorithms. Next is `v0.4.5`.

## Noticed while checking, not fixed here

`package-lock.json` still records `packages/mcp` at **0.1.0** — three versions stale. It is evidently not kept in sync with package versions and is not part of what gets published.

## What follows

The measurement is not immediate: the downloads API lags ~6 days. The re-run of the 29.08. measurement battery is the acceptance test, and until it is done this release has changed nothing that can be claimed.