### PR TITLE
fix(mcp): start the server when launched through the npm bin symlink

### DIFF
--- a/packages/mcp/__tests__/entry-guard.test.ts
+++ b/packages/mcp/__tests__/entry-guard.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The guard that decides whether the bin entry actually starts the server.
+ *
+ * Measured on 0.1.4: `npm i -g @zensation/mcp` then `zenbrain-mcp`, and
+ * `npx -y @zensation/mcp` — the two ways the README tells people to start the
+ * server — both exited **0 with an empty stdout and an empty stderr**. `main()`
+ * was never reached, because npm installs every `bin` as a symlink and the guard
+ * compared `import.meta.url` (symlinks resolved) against `process.argv[1]`
+ * (symlink path as spelled). Only `node <realpath>` came up.
+ *
+ * Two levels on purpose. The unit tests pin the comparison rule and are cheap.
+ * They are not enough: a pure-function test passes just as happily while the
+ * installed binary stays dead, which is exactly how this shipped. So the last
+ * test spawns the built entry point **through a real symlink** — the arrangement
+ * npm creates — and requires an answer on the wire.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isDirectInvocation } from '../src/index.js';
+
+const hier = dirname(fileURLToPath(import.meta.url));
+const gebauteDatei = join(hier, '..', 'dist', 'index.js');
+
+describe('the entry guard', () => {
+  it('recognises a plain direct run, where no symlink is involved', () => {
+    const pfad = '/pkg/dist/index.js';
+    expect(isDirectInvocation(pathToFileURL(pfad).href, pfad, (p) => p)).toBe(true);
+  });
+
+  it('recognises the npm bin symlink — the case that shipped broken', () => {
+    const echt = '/usr/local/lib/node_modules/@zensation/mcp/dist/index.js';
+    const link = '/usr/local/bin/zenbrain-mcp';
+    expect(
+      isDirectInvocation(pathToFileURL(echt).href, link, (p) => (p === link ? echt : p)),
+    ).toBe(true);
+  });
+
+  it('still says no when the module was imported rather than run', () => {
+    const anderes = '/pkg/dist/some-other-entry.js';
+    expect(
+      isDirectInvocation(pathToFileURL('/pkg/dist/index.js').href, anderes, (p) => p),
+    ).toBe(false);
+  });
+
+  it('says no instead of throwing when argv[1] is absent or unresolvable', () => {
+    const url = pathToFileURL('/pkg/dist/index.js').href;
+    expect(isDirectInvocation(url, undefined)).toBe(false);
+    expect(
+      isDirectInvocation(url, '/nope', () => {
+        throw new Error('ENOENT');
+      }),
+    ).toBe(false);
+  });
+
+  it('handles paths a `file://${path}` template would misread', () => {
+    // Measured on Node 22: a space comes out the same either way, but `#`, `?`
+    // and `%` do not — the template hands them to the URL parser as fragment,
+    // query and escape introducer instead of as filename characters.
+    for (const pfad of ['/pkg/a#b/dist/index.js', '/pkg/a?b/dist/index.js', '/pkg/a%b/dist/index.js']) {
+      expect(isDirectInvocation(pathToFileURL(pfad).href, pfad, (p) => p), pfad).toBe(true);
+      expect(new URL(`file://${pfad}`).href, pfad).not.toBe(pathToFileURL(pfad).href);
+    }
+  });
+
+  it('answers MCP when started through a symlink, the way npm installs it', async () => {
+    expect(
+      existsSync(gebauteDatei),
+      `${gebauteDatei} is missing — run \`npm run build\` in packages/mcp first. ` +
+        'This test deliberately does not skip: it is the only one that exercises the ' +
+        'path that shipped broken.',
+    ).toBe(true);
+
+    const verzeichnis = mkdtempSync(join(tmpdir(), 'zenbrain-bin-'));
+    const link = join(verzeichnis, 'zenbrain-mcp');
+    symlinkSync(gebauteDatei, link);
+
+    const antwort = await new Promise<string>((loese, scheitere) => {
+      const kind = spawn(process.execPath, [link], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, ZENBRAIN_DB: ':memory:' },
+      });
+      let aus = '';
+      let fehler = '';
+      const uhr = setTimeout(() => {
+        kind.kill();
+        scheitere(
+          new Error(
+            `no MCP response within 15s. stdout=${JSON.stringify(aus)} ` +
+              `stderr=${JSON.stringify(fehler)}`,
+          ),
+        );
+      }, 15_000);
+
+      kind.stdout.on('data', (d) => {
+        aus += String(d);
+        for (const zeile of aus.split('\n')) {
+          if (!zeile.trim().startsWith('{')) continue;
+          try {
+            const nachricht = JSON.parse(zeile);
+            if (nachricht.id === 1 && nachricht.result) {
+              clearTimeout(uhr);
+              kind.kill();
+              loese(zeile);
+            }
+          } catch {
+            // a partial line; wait for the rest
+          }
+        }
+      });
+      kind.stderr.on('data', (d) => (fehler += String(d)));
+      kind.on('error', scheitere);
+
+      kind.stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'entry-guard-test', version: '1.0.0' },
+          },
+        }) + '\n',
+      );
+    });
+
+    const ergebnis = JSON.parse(antwort).result;
+    expect(ergebnis.serverInfo).toBeDefined();
+    expect(ergebnis.capabilities).toBeDefined();
+  }, 20_000);
+});

--- a/packages/mcp/__tests__/reported-version.test.ts
+++ b/packages/mcp/__tests__/reported-version.test.ts
@@ -1,0 +1,69 @@
+/**
+ * What the server tells a client it is.
+ *
+ * Measured on 0.1.4: every client saw `@zensation/mcp 0.1.0`. `createZenBrainServer`
+ * carried a written-out fallback of `'0.1.0'`, and `index.ts` — the real entry
+ * point — calls it with no options at all, so the fallback was what shipped. It
+ * had been wrong for four releases.
+ *
+ * The existing protocol tests did not catch it and could not: they construct the
+ * server with `{ version: '0.1.0-test' }` and therefore never exercise the
+ * default. This file drives the path `index.ts` actually takes — no options —
+ * and compares against the manifest rather than against a second written-out
+ * literal, which would only move the staleness one file over.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  MemoryCoordinator,
+  InMemoryStorage,
+  FakeEmbeddingProvider,
+  InMemoryCache,
+} from '@zensation/core';
+import { createZenBrainServer } from '../src/server.js';
+
+const manifest = createRequire(import.meta.url)('../package.json') as {
+  name: string;
+  version: string;
+};
+
+let client: Client;
+let coordinator: MemoryCoordinator;
+
+beforeEach(async () => {
+  coordinator = new MemoryCoordinator({
+    storage: new InMemoryStorage(),
+    embedding: new FakeEmbeddingProvider(),
+    cache: new InMemoryCache(),
+  });
+  // No options — exactly what `index.ts` does.
+  const server = createZenBrainServer(coordinator);
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: 'version-test', version: '1.0.0' });
+  await Promise.all([client.connect(clientSide), server.connect(serverSide)]);
+});
+
+afterEach(async () => {
+  await client.close();
+  await coordinator.close();
+});
+
+describe('the version the server reports', () => {
+  it('is the package version, not a written-out literal', () => {
+    expect(client.getServerVersion()?.version).toBe(manifest.version);
+  });
+
+  it('is not the stale 0.1.0 that shipped for four releases', () => {
+    // Guards the specific regression rather than only the general rule: if the
+    // manifest ever goes back to 0.1.0 the test above would pass while the bug
+    // is back.
+    expect(manifest.version).not.toBe('0.1.0');
+    expect(client.getServerVersion()?.version).not.toBe('0.1.0');
+  });
+
+  it('reports the package name too', () => {
+    expect(client.getServerVersion()?.name).toBe(manifest.name);
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zensation/mcp",
-  "version": "0.1.4",
-  "description": "MCP memory server for ZenBrain: agent memory for any Model Context Protocol client — store, recall, consolidate, health. Local SQLite file, no account.",
+  "version": "0.1.5",
+  "description": "MCP memory server for ZenBrain: agent memory for any Model Context Protocol client \u2014 store, recall, consolidate, health. Local SQLite file, no account.",
   "mcpName": "ai.zensation/zenbrain",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,8 @@
  * Nothing is written to stdout except protocol traffic — stdout *is* the
  * transport. Diagnostics go to stderr.
  */
+import { realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createZenBrainServer } from './server.js';
 
@@ -87,14 +89,44 @@ async function main(): Promise<void> {
   process.stderr.write(`zenbrain-mcp ready — store: ${filename}\n`);
 }
 
-// Only run when executed, not when imported. `process.argv[1]` is the script
-// path the runtime was handed; comparing against import.meta.url is the
-// ESM-safe form of the CommonJS `require.main === module` check.
-const invokedDirectly =
-  process.argv[1] !== undefined &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+/**
+ * Is this module the program the runtime was asked to run, or was it imported?
+ *
+ * `process.argv[1]` is the path as the caller spelled it. `import.meta.url` is
+ * that path *after* the loader resolved symlinks. npm installs every `bin` as a
+ * symlink — `/usr/local/bin/zenbrain-mcp -> ../lib/node_modules/@zensation/mcp/dist/index.js`
+ * — so for an installed package the two spellings never match, and comparing
+ * them unresolved left `main()` unreachable.
+ *
+ * Measured on 0.1.4 before this was fixed: `npm i -g @zensation/mcp` then
+ * `zenbrain-mcp`, and `npx -y @zensation/mcp` — the two ways the README tells
+ * people to start the server — both exited **0 with an empty stdout and an
+ * empty stderr**. Only `node <realpath>` came up. A silent no-op on the
+ * documented path is the same failure the Node guard above exists to prevent.
+ *
+ * So resolve the argv path the way the loader resolved this module, and compare
+ * like with like. `pathToFileURL` rather than a `file://${path}` template: the
+ * template hands `#`, `?` and `%` to the URL parser as fragment, query and
+ * escape introducer instead of as filename characters (measured on Node 22; a
+ * space, contrary to what one would guess, comes out the same either way).
+ *
+ * `resolve` is injectable so the symlink case can be tested without one.
+ */
+export function isDirectInvocation(
+  moduleUrl: string,
+  argv1: string | undefined,
+  resolve: (path: string) => string = realpathSync,
+): boolean {
+  if (argv1 === undefined) return false;
+  try {
+    return moduleUrl === pathToFileURL(resolve(argv1)).href;
+  } catch {
+    // argv[1] names something unresolvable; that is not a direct invocation.
+    return false;
+  }
+}
 
-if (invokedDirectly) {
+if (isDirectInvocation(import.meta.url, process.argv[1])) {
   main().catch((err: unknown) => {
     process.stderr.write(`zenbrain-mcp failed to start: ${String(err)}\n`);
     process.exit(1);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -6,6 +6,7 @@
  * drive the real protocol over an in-memory transport against an in-memory store,
  * and never touch a file or a database. `index.ts` does the wiring for real use.
  */
+import { createRequire } from 'node:module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type {
@@ -14,6 +15,22 @@ import type {
   RecallResult,
   StoreOptions,
 } from '@zensation/core';
+
+/**
+ * The version the server reports to clients that do not pass one.
+ *
+ * Read from the manifest, not written out here. The literal that used to stand
+ * in this place said `0.1.0` while the package was at 0.1.4, so every client
+ * saw a version that had been stale for four releases — and the test suite
+ * never caught it, because it passes a version of its own and therefore never
+ * exercised the default. A constant that has to be remembered on each release
+ * is a constant that goes stale.
+ *
+ * `../package.json` resolves to the package root from both `src/` and `dist/`.
+ */
+const PACKAGE_VERSION: string = (
+  createRequire(import.meta.url)('../package.json') as { version: string }
+).version;
 
 /** Layer names the coordinator accepts in `RecallOptions.layers`. */
 const LAYERS = ['working', 'episodic', 'semantic', 'procedural', 'core'] as const;
@@ -45,7 +62,7 @@ export function createZenBrainServer(
 ): McpServer {
   const server = new McpServer({
     name: options.name ?? '@zensation/mcp',
-    version: options.version ?? '0.1.0',
+    version: options.version ?? PACKAGE_VERSION,
   });
 
   // ── store ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What is wrong

`zenbrain-mcp` does not start. Not slowly, not with an error — it exits 0 and
writes nothing to stdout or stderr.

The entry guard compared `import.meta.url` (symlinks resolved by the loader)
against `process.argv[1]` (the path as the caller spelled it). npm installs
every `bin` as a symlink:

```
/usr/local/bin/zenbrain-mcp -> ../lib/node_modules/@zensation/mcp/dist/index.js
```

so for an installed package the two spellings never match, `invokedDirectly` is
always `false`, and `main()` is unreachable.

## Measured, not assumed

All three invocation paths against `@zensation/mcp@0.1.4` in `node:22-slim`,
with `@modelcontextprotocol/server-memory` probed identically on the same image
as a positive control (it answered, so the probe harness is not the cause):

| How it is started | Result |
|---|---|
| `npm i -g @zensation/mcp` then `zenbrain-mcp` | exit 0, stdout empty, stderr empty |
| `npx -y @zensation/mcp` | exit 0, stdout empty, stderr empty |
| `node <realpath>/dist/index.js` | `initialize` answered, 4 tools listed |

The first two are exactly what this package's README documents — the install
line and the `"command": "npx"` client config. So the documented path has been
a silent no-op since the guard was introduced.

This is the same failure mode the Node version guard immediately above it was
written to prevent: "the server simply never comes up, with nothing to go on."

## The fix

Resolve the argv path the way the loader resolved this module, then compare
like with like. `pathToFileURL` rather than a `file://${path}` template — the
template hands `#`, `?` and `%` to the URL parser as fragment, query and escape
introducer instead of as filename characters (measured on Node 22; a space,
contrary to what one would guess, comes out the same either way).

The check moves into an exported `isDirectInvocation()` with an injectable
resolver, so the symlink arrangement is testable without creating one.

## Why there are two levels of test

The unit tests would not have caught this. Verified rather than assumed: with
the old call site restored, all five unit tests stay **green** and only the test
that spawns the built entry point through a real symlink goes **red** — with the
original symptom, `no MCP response within 15s. stdout="" stderr=""`.

That is why the last test insists on an answer on the wire, and why it fails
loudly instead of skipping when `dist/` is missing: it is the only one that
exercises the path that shipped broken.

Full suite on `node:22-slim`: build ok, `tsc --noEmit` ok, 27/27 tests pass.

## Version

`packages/mcp` goes 0.1.4 → 0.1.5. Publishing is the usual tokenless OIDC
trusted publish on a `v*` tag, idempotent per package.

## Found next to this, deliberately NOT in this PR

`src/server.ts:48` reads `version: options.version ?? '0.1.0'`, and
`src/index.ts` calls `createZenBrainServer(coordinator)` without options. So the
server reports itself as **0.1.0** to every client regardless of the package
version — visible in the probe output above. It is a one-line change, but it is
a different defect from this one and belongs in its own commit.