### PR TITLE
chore: glama.json, damit die Glama-Listung beanspruchbar wird

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "alexanderbering"
+  ]
+}


### PR DESCRIPTION
## Warum

Die Glama-Listung `zensation-ai/zenbrain` ist seit dem 12.09. **live** (Serverseite HTTP 200, vorher 404) und trägt eine Note — aber nur auf zwei von drei Dimensionen. Das Badge rendert **`A – B`**, die mittlere Stelle ist leer:

```
unseres : "official vendor server, maintenance rated B"
Kontrolle (ohad6k/emulo) : "claimed by its maintainer, tool definitions rated A, 1 tool, maintenance rated A"
```

Der Bot auf [punkpeye/awesome-mcp-servers#13128](https://github.com/punkpeye/awesome-mcp-servers/pull/13128) verlangt genau diese fehlende Dimension: *„Please make sure the server has been evaluated by Glama and has a quality score."*

## Was gemessen wurde

Auf der Admin-Seite der Listung steht die Ursache wörtlich:

> **Docker builds** — Configure the build spec Glama uses to containerise the server, cut releases, and read the logs when a build fails.
>
> You are signed in, but Glama does not yet see you as a maintainer of this server.

Und auf der Übersicht, ausgegraut: **„Deploy Server — This server cannot be deployed."** Die Quality-Dimension entsteht aus einem Docker-Build, den Glama selbst fährt; die Einstellung dafür liegt hinter dem Claim.

Glama nennt zwei Wege zum Claim. Für ein Repository, das einer **Organisation** gehört — und `zensation-ai` ist an der API als `type: Organization` bestätigt — ist es dieser:

> Add `glama.json` to the root of the repository with your GitHub username under `maintainers`, then sign in. Glama recognises you on the next sync.

## Der Inhalt

Format **wörtlich von der Admin-Seite übernommen**, nicht geraten. Der Benutzername ist an der API gemessen (`gh api user` → `alexanderbering`), nicht aus einer Notiz abgeschrieben — im Umlauf waren zwei Schreibweisen.

**Keine Zeile Code berührt**, eine neue Datei im Wurzelverzeichnis.

## Danach

Nach dem nächsten Glama-Sync wird die Admin-Seite beanspruchbar, der Docker-Build lässt sich konfigurieren, und die Quality-Dimension entsteht. Das dafür **gebaute und getestete** Dockerfile liegt bereit (`initialize` beantwortet, vier Tools gelistet).